### PR TITLE
load lpsolve jni lib from env var

### DIFF
--- a/extra/lp_solve_5.5_java/src/java/lpsolve/LpSolve.java
+++ b/extra/lp_solve_5.5_java/src/java/lpsolve/LpSolve.java
@@ -272,7 +272,14 @@ public class LpSolve {
 	 * Static initializer to load the stub library
 	 */
 	static {
-		System.loadLibrary("lpsolve55j");
+		String lpSolveJNILibPath = System.getenv("LP_SOLVE_JNI_LIB_PATH");
+		if (lpSolveJNILibPath != null) {
+			// If the environment variable is set, load the library from that path
+			System.load(lpSolveJNILibPath);
+		} else {
+			// Otherwise, assume the library is in the default library path
+			System.loadLibrary("lpsolve55j");
+		}
 		init();
 	}
 


### PR DESCRIPTION
System.loadLibrary requires the native library (e.g., liblpsolve55j.so or .jnilib) to be discoverable in java.library.path. This can be inflexible and problematic in some deployment setups. System.load allows you to specify the absolute path to the native library, bypassing java.library.path issues and giving you full control.

This pull request introduces a change to the static initializer in the `LpSolve` class to enhance the flexibility of loading the JNI library. The update allows the library path to be specified via an environment variable, improving configurability for different deployment environments.

### Changes to library loading logic:

* [`extra/lp_solve_5.5_java/src/java/lpsolve/LpSolve.java`](diffhunk://#diff-f2e9921d63cc85b5a19263d4ccf35f7adcbcfcb8fe70851a96563b7812e71d83R275-R282): Modified the static initializer to check for the `LP_SOLVE_JNI_LIB_PATH` environment variable. If set, the library is loaded from the specified path; otherwise, the default library path is used.