### PR TITLE
Use GitHub actions to prepare release files

### DIFF
--- a/.github/workflows/release-files.yaml
+++ b/.github/workflows/release-files.yaml
@@ -1,0 +1,774 @@
+name: 'Prepare Release Files'
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+.[0-9]+'
+    branches:
+      - 'gh-actions-release-files*' # TODO: For testing the workflow only
+
+jobs:
+  determine-version:
+    runs-on: ubuntu-latest
+
+    outputs:
+      LPSOLVE_VERSION: ${{ steps.extract-version.outputs.LPSOLVE_VERSION }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v5
+
+    # TODO: in a real release, we _might_ want to extract that number from the tag instead
+    #       or maybe update the values in lp_lib.h based on the values extracted from the tag
+    - name: Extract Version Number
+      id: extract-version
+      # lp_lib.h contains the version information as:
+      #     #define MAJORVERSION  5
+      #     #define MINORVERSION  5
+      #     #define RELEASE       2
+      #     #define BUILD        14
+      run: |
+        LP_MAJOR=$( sed -n -E 's/^\s*#define\s+MAJORVERSION\s+([0-9]+).*$/\1/p' $GITHUB_WORKSPACE/lp_lib.h )
+        LP_MINOR=$( sed -n -E 's/^\s*#define\s+MINORVERSION\s+([0-9]+).*$/\1/p' $GITHUB_WORKSPACE/lp_lib.h )
+        LP_RELEASE=$( sed -n -E 's/^\s*#define\s+RELEASE\s+([0-9]+).*$/\1/p' $GITHUB_WORKSPACE/lp_lib.h )
+        LP_BUILD=$( sed -n -E 's/^\s*#define\s+BUILD\s+([0-9]+).*$/\1/p' $GITHUB_WORKSPACE/lp_lib.h )
+        LPSOLVE_VERSION=$LP_MAJOR.$LP_MINOR.$LP_RELEASE.$LP_BUILD
+        echo "Version is $LPSOLVE_VERSION"
+        echo "LPSOLVE_VERSION=$LPSOLVE_VERSION" >> "$GITHUB_OUTPUT"
+
+  build-win64:
+    needs: determine-version
+    runs-on: windows-latest
+
+    env:
+      LPSOLVE_VERSION: ${{ needs.determine-version.outputs.LPSOLVE_VERSION }}
+      LPSOLVE_PLATFORM: 'win64'
+
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v5
+
+    - name: Configure build tools
+      uses: ilammy/msvc-dev-cmd@v1
+      with:
+        arch: ${{ env.LPSOLVE_PLATFORM }}
+
+    - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_dev_${{ env.LPSOLVE_PLATFORM }}.zip
+      run: |
+        echo "Building lpsolve55 library for platform $env:LPSOLVE_PLATFORM"
+        pushd $env:GITHUB_WORKSPACE/lpsolve55
+        ./cvc8NOmsvcrt.bat
+        popd
+
+        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_dev_${{ env.LPSOLVE_PLATFORM }}.zip"
+
+        echo "Packaging files from $PWD"
+        7z a -tzip -bso0 -bsp0 $zipPath `
+          lp_Hash.h `
+          lp_lib.h `
+          lp_matrix.h `
+          lp_mipbb.h `
+          lp_SOS.h `
+          lp_types.h `
+          lp_utils.h
+
+        cd lpsolve55/bin/${{ env.LPSOLVE_PLATFORM }}
+        echo "Packaging files from $PWD"
+        7z a -tzip -bso0 -bsp0 $zipPath `
+          * `
+          '-x!lpsolve55.exp'
+
+    # TODO: zip here reproduces what was released with 5.5.2.14 which is missing files compared to 5.5.2.11:
+    #       bfp_etaPFI.dll
+    #       bfp_GLPK.dll
+    #       bfp_LUSOL.dll
+    #       contents.txt
+    #       xli_CPLEX.dll
+    #       xli_DIMACS.dll
+    #       xli_LINDO.dll
+    #       xli_MathProg.dll
+    #       xli_MPS.dll
+    #       xli_XPRESS.dll
+    - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_exe_${{ env.LPSOLVE_PLATFORM }}.zip
+      run: |
+        echo "Building lp_solve.exe for platform $env:LPSOLVE_PLATFORM"
+        pushd $env:GITHUB_WORKSPACE/lp_solve
+        ./cvc8.bat
+        popd
+
+        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_exe_${{ env.LPSOLVE_PLATFORM }}.zip"
+
+        cd $env:GITHUB_WORKSPACE/lp_solve/bin/${{ env.LPSOLVE_PLATFORM }}
+        echo "Packaging files from $PWD"
+        7z a -tzip -bso0 -bsp0 $zipPath lp_solve.exe
+
+    # TODO: zip here reproduces what was released with 5.5.2.14 which is missing files compared to 5.5.2.11:
+    #       bin/win64/lp_explicit.lib
+    #       mxlpsolve.mexw64
+    # If we decide not to ship those anymore, should we include Makefile.m instead like MATLAB.htm describes?
+    # Maybe also the *.h and *.c that might be needed to build these within MATLAB?
+    - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_MATLAB_exe_${{ env.LPSOLVE_PLATFORM }}.zip
+      run: |
+        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_MATLAB_exe_${{ env.LPSOLVE_PLATFORM }}.zip"
+
+        cd $env:GITHUB_WORKSPACE/extra/MATLAB/lpsolve
+        echo "Packaging files from $PWD"
+        7z a -tzip -bso0 -bsp0 $zipPath `
+            *.m `
+            changes `
+            README.txt `
+            '-x!Makefile.m'
+
+        cd $env:GITHUB_WORKSPACE/extra/man
+        echo "Packaging files from $PWD"
+        7z a -tzip -bso0 -bsp0 $zipPath `
+            MATLAB.htm
+
+    # TODO: zip here reproduces what was released with 5.5.2.14 which is missing files compared to 5.5.2.11:
+    #       bin/win64/sclpsolve.dll
+    #       macros/lib
+    # If we decide not to ship those anymore, should we include src/ folder?
+    - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_scilab_exe_${{ env.LPSOLVE_PLATFORM }}.zip
+      run: |
+        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_scilab_exe_${{ env.LPSOLVE_PLATFORM }}.zip"
+
+        cd $env:GITHUB_WORKSPACE/extra/scilab/lpsolve
+        echo "Packaging files from $PWD"
+        7z a -tzip -bso0 -bsp0 -r $zipPath `
+            * `
+            '-x!src/'
+
+        cd $env:GITHUB_WORKSPACE/extra/man
+        echo "Packaging files from $PWD"
+        7z a -tzip -bso0 -bsp0 $zipPath `
+            Scilab.htm
+
+    - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}.chm
+      run: |
+        cd $env:GITHUB_WORKSPACE/extra/man
+        ./gen.bat
+        cp *.chm $env:GITHUB_WORKSPACE
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ env.LPSOLVE_PLATFORM }}
+        compression-level: 0 # no compression - already compressed
+        retention-days: 1
+        path: |
+          *.zip
+          *.chm
+
+  build-win32:
+    needs: determine-version
+    runs-on: windows-latest
+
+    env:
+      LPSOLVE_VERSION: ${{ needs.determine-version.outputs.LPSOLVE_VERSION }}
+      LPSOLVE_PLATFORM: 'win32'
+
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v5
+
+    - name: Configure build tools
+      uses: ilammy/msvc-dev-cmd@v1
+      with:
+        arch: ${{ env.LPSOLVE_PLATFORM }}
+
+    - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_dev_${{ env.LPSOLVE_PLATFORM }}.zip
+      run: |
+        echo "Building lpsolve55 library for platform $env:LPSOLVE_PLATFORM"
+        pushd $env:GITHUB_WORKSPACE/lpsolve55
+        ./cvc8NOmsvcrt.bat
+        popd
+
+        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_dev_${{ env.LPSOLVE_PLATFORM }}.zip"
+
+        echo "Packaging files from $PWD"
+        7z a -tzip -bso0 -bsp0 $zipPath `
+          lp_Hash.h `
+          lp_lib.h `
+          lp_matrix.h `
+          lp_mipbb.h `
+          lp_SOS.h `
+          lp_types.h `
+          lp_utils.h
+
+        cd lpsolve55/bin/${{ env.LPSOLVE_PLATFORM }}
+        echo "Packaging files from $PWD"
+        7z a -tzip -bso0 -bsp0 $zipPath `
+          * `
+          '-x!lpsolve55.exp'
+
+    # TODO: zip here reproduces what was released with 5.5.2.14 which is missing files compared to 5.5.2.11:
+    #       bfp_etaPFI.dll
+    #       bfp_GLPK.dll
+    #       bfp_LUSOL.dll
+    #       contents.txt
+    #       xli_CPLEX.dll
+    #       xli_DIMACS.dll
+    #       xli_LINDO.dll
+    #       xli_LPFML.dll
+    #       xli_MathProg.dll
+    #       xli_MPS.dll
+    #       xli_XPRESS.dll
+    #       xli_ZIMPL.dll
+    - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_exe_${{ env.LPSOLVE_PLATFORM }}.zip
+      run: |
+        echo "Building lp_solve.exe for platform $env:LPSOLVE_PLATFORM"
+        pushd $env:GITHUB_WORKSPACE/lp_solve
+        ./cvc8.bat
+        popd
+
+        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_exe_${{ env.LPSOLVE_PLATFORM }}.zip"
+
+        cd $env:GITHUB_WORKSPACE/lp_solve/bin/${{ env.LPSOLVE_PLATFORM }}
+        echo "Packaging files from $PWD"
+        7z a -tzip -bso0 -bsp0 $zipPath lp_solve.exe
+
+    # TODO: zip here reproduces what was released with 5.5.2.14 which is missing files compared to 5.5.2.11:
+    #       lpsolve.exe (which seems to be built from extra/AMPL/solvers/lpsolve/makefile5*.vc)
+    - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_AMPL_exe_${{ env.LPSOLVE_PLATFORM }}.zip
+      run: |
+        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_AMPL_exe_${{ env.LPSOLVE_PLATFORM }}.zip"
+
+        cd $env:GITHUB_WORKSPACE/extra/AMPL/solvers/lpsolve
+        echo "Packaging files from $PWD"
+        7z a -tzip -bso0 -bsp0 $zipPath `
+            changes `
+            README
+
+        cd $env:GITHUB_WORKSPACE/extra/man
+        echo "Packaging files from $PWD"
+        7z a -tzip -bso0 -bsp0 $zipPath `
+            AMPL.htm
+
+    # TODO: zip here reproduces what was released with 5.5.2.14 which is missing files compared to 5.5.2.11:
+    #       eulpsolve.dll(which seems to be built from extra/Euler/cvc.bat)
+    #       intsimplex.e
+    #       loadlpsolve.en
+    #       loadlpsolve70.en
+    #       Test Problems.en
+    - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_Euler_exe_${{ env.LPSOLVE_PLATFORM }}.zip
+      run: |
+        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_Euler_exe_${{ env.LPSOLVE_PLATFORM }}.zip"
+
+        cd $env:GITHUB_WORKSPACE/extra/Euler
+        echo "Packaging files from $PWD"
+        7z a -tzip -bso0 -bsp0 $zipPath `
+            changes `
+            *.en `
+            *.e `
+            README.txt
+
+        cd $env:GITHUB_WORKSPACE/extra/man
+        echo "Packaging files from $PWD"
+        7z a -tzip -bso0 -bsp0 $zipPath `
+            Euler.htm
+
+    # TODO: zip here reproduces what was released with 5.5.2.14 which is missing files compared to 5.5.2.11:
+    #       fmlpsolve.dll(which seems to be built from extra/FreeMat/cvc.bat)
+    - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_FreeMat_exe_${{ env.LPSOLVE_PLATFORM }}.zip
+      run: |
+        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_FreeMat_exe_${{ env.LPSOLVE_PLATFORM }}.zip"
+
+        cd $env:GITHUB_WORKSPACE/extra/FreeMat
+        echo "Packaging files from $PWD"
+        7z a -tzip -bso0 -bsp0 $zipPath `
+            changes `
+            *.m `
+            README.txt
+
+        cd $env:GITHUB_WORKSPACE/extra/man
+        echo "Packaging files from $PWD"
+        7z a -tzip -bso0 -bsp0 $zipPath `
+            FreeMat.htm
+
+    # TODO: zip here reproduces what was released with 5.5.2.14 which is missing files compared to 5.5.2.11:
+    #       bin/win32/lp_explicit.lib
+    #       mxlpsolve.dll
+    #       mxlpsolve.mexw32
+    # If we decide not to ship those anymore, should we include Makefile.m instead like MATLAB.htm describes?
+    # Maybe also the *.h and *.c that might be needed to build these within MATLAB?
+    - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_MATLAB_exe_${{ env.LPSOLVE_PLATFORM }}.zip
+      run: |
+        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_MATLAB_exe_${{ env.LPSOLVE_PLATFORM }}.zip"
+
+        cd $env:GITHUB_WORKSPACE/extra/MATLAB/lpsolve
+        echo "Packaging files from $PWD"
+        7z a -tzip -bso0 -bsp0 $zipPath `
+            *.m `
+            changes `
+            README.txt `
+            '-x!Makefile.m'
+
+        cd $env:GITHUB_WORKSPACE/extra/man
+        echo "Packaging files from $PWD"
+        7z a -tzip -bso0 -bsp0 $zipPath `
+            MATLAB.htm
+
+    # TODO: This only contains an HTML file, do we still want to release this?
+    - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_MSF_exe_${{ env.LPSOLVE_PLATFORM }}.zip
+      run: |
+        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_MSF_exe_${{ env.LPSOLVE_PLATFORM }}.zip"
+
+        cd $env:GITHUB_WORKSPACE/extra/man
+        echo "Packaging files from $PWD"
+        7z a -tzip -bso0 -bsp0 $zipPath `
+            MSF.htm
+
+    # TODO: zip here reproduces what was released with 5.5.2.14 which is missing files compared to 5.5.2.11:
+    #       octlpsolve.oct
+    - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_octave_exe_${{ env.LPSOLVE_PLATFORM }}.zip
+      run: |
+        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_octave_exe_${{ env.LPSOLVE_PLATFORM }}.zip"
+
+        cd $env:GITHUB_WORKSPACE/extra/octave/lpsolve
+        echo "Packaging files from $PWD"
+        7z a -tzip -bso0 -bsp0 -r $zipPath `
+            changes `
+            *.m `
+            README.txt
+
+    # TODO: zip here reproduces what was released with 5.5.2.14 which is missing files compared to 5.5.2.11:
+    #       omlpsolve.dll (which seems built from cvc.bat)
+    - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_OMATRIX_exe_${{ env.LPSOLVE_PLATFORM }}.zip
+      run: |
+        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_OMATRIX_exe_${{ env.LPSOLVE_PLATFORM }}.zip"
+
+        cd $env:GITHUB_WORKSPACE/extra/O-MATRIX/lpsolve
+        echo "Packaging files from $PWD"
+        7z a -tzip -bso0 -bsp0 -r $zipPath `
+            changes `
+            *.oms `
+            README.txt
+
+        cd $env:GITHUB_WORKSPACE/extra/man
+        echo "Packaging files from $PWD"
+        7z a -tzip -bso0 -bsp0 $zipPath `
+            O-Matrix.htm
+
+    # TODO: zip here reproduces what was released with 5.5.2.14 which is missing files compared to 5.5.2.11:
+    #       php4/php_phplpsolve55.dll
+    #       php5_2/php_phplpsolve55.dll
+    #       php5_3/php_phplpsolve55.dll
+    - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_PHP_exe_${{ env.LPSOLVE_PLATFORM }}.zip
+      run: |
+        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_PHP_exe_${{ env.LPSOLVE_PLATFORM }}.zip"
+
+        cd $env:GITHUB_WORKSPACE/extra/PHP
+        echo "Packaging files from $PWD"
+        7z a -tzip -bso0 -bsp0 -r $zipPath `
+            changes `
+            *.php `
+            README.txt
+
+        cd $env:GITHUB_WORKSPACE/extra/man
+        echo "Packaging files from $PWD"
+        7z a -tzip -bso0 -bsp0 $zipPath `
+            PHP.htm
+
+    # TODO: zip here reproduces what was released with 5.5.2.14 which is missing files compared to 5.5.2.11:
+    #       bin/win32/sclpsolve.dll
+    #       macros/lib
+    # If we decide not to ship those anymore, should we include src/ folder?
+    - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_scilab_exe_${{ env.LPSOLVE_PLATFORM }}.zip
+      run: |
+        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_scilab_exe_${{ env.LPSOLVE_PLATFORM }}.zip"
+
+        cd $env:GITHUB_WORKSPACE/extra/scilab/lpsolve
+        echo "Packaging files from $PWD"
+        7z a -tzip -bso0 -bsp0 -r $zipPath `
+            * `
+            '-x!src/'
+
+        cd $env:GITHUB_WORKSPACE/extra/man
+        echo "Packaging files from $PWD"
+        7z a -tzip -bso0 -bsp0 $zipPath `
+            Scilab.htm
+
+    # TODO: zip here reproduces what was released with 5.5.2.14 which is missing files compared to 5.5.2.11:
+    #       sqlpsolveext.dll (seems to be built from cvc.bat)
+    - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_Sysquake_exe_${{ env.LPSOLVE_PLATFORM }}.zip
+      run: |
+        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_Sysquake_exe_${{ env.LPSOLVE_PLATFORM }}.zip"
+
+        cd $env:GITHUB_WORKSPACE/extra/Sysquake
+        echo "Packaging files from $PWD"
+        7z a -tzip -bso0 -bsp0 -r $zipPath `
+            changes `
+            *.lml `
+            README.txt
+
+        cd $env:GITHUB_WORKSPACE/extra/man
+        echo "Packaging files from $PWD"
+        7z a -tzip -bso0 -bsp0 $zipPath `
+            Sysquake.htm
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ env.LPSOLVE_PLATFORM }}
+        compression-level: 0 # no compression - already compressed
+        retention-days: 1
+        path: |
+          *.zip
+
+  zip-on-windows:
+    needs: determine-version
+    runs-on: windows-latest
+
+    env:
+      LPSOLVE_VERSION: ${{ needs.determine-version.outputs.LPSOLVE_VERSION }}
+
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v5
+
+    - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_access.zip
+      run: |
+        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_access.zip"
+
+        cd $env:GITHUB_WORKSPACE/extra/Access
+        echo "Packaging files from $PWD"
+        7z a -tzip -bso0 -bsp0 $zipPath `
+          demo.mdb
+
+    # TODO: zip here reproduces what was released with 5.5.2.14 which is missing files compared to 5.5.2.11:
+    #       lpsolve55COM.dll
+    - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_COM.zip
+      run: |
+        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_COM.zip"
+
+        cd $env:GITHUB_WORKSPACE/extra/COM
+        echo "Packaging files from $PWD"
+        7z a -tzip -bso0 -bsp0 -r $zipPath `
+          * `
+          '-x!demo.vbg' `
+          '-x!lpsolve55ASP.cls'
+
+    - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_cs.net.zip
+      run: |
+        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_cs.net.zip"
+
+        cd $env:GITHUB_WORKSPACE/extra/cs.net
+        echo "Packaging files from $PWD"
+        7z a -tzip -bso0 -bsp0 $zipPath `
+          * `
+          '-x!app.config'
+
+    - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_Delphi.zip
+      run: |
+        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_Delphi.zip"
+
+        cd $env:GITHUB_WORKSPACE/extra/Delphi
+        echo "Packaging files from $PWD"
+        7z a -tzip -bso0 -bsp0 $zipPath `
+          cppc.bat `
+          demo.dpr `
+          lp.lp `
+          lpsolve.inc `
+          lpsolve.pas
+
+    - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_excel.zip
+      run: |
+        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_excel.zip"
+
+        cd $env:GITHUB_WORKSPACE/extra/excel
+        echo "Packaging files from $PWD"
+        7z a -tzip -bso0 -bsp0 $zipPath `
+          demo.xls
+
+    - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_IDE_source.zip
+      run: |
+        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_IDE_source.zip"
+
+        cd $env:GITHUB_WORKSPACE/extra/LPSolveIDE/IDE15
+        echo "Packaging files from $PWD"
+        7z a -tzip -bso0 -bsp0 $zipPath `
+          InnoSetup/L* `
+          *.*
+
+    # TODO: zip here reproduces what was released with 5.5.2.14 which is missing files compared to 5.5.2.11:
+    #       lib/mac/build-osx
+    #       lib/ux32/liblpsolve55j.so
+    #       lib/ux64/liblpsolve55j.so
+    #       lib/win32/lpsolve55j.dll
+    #       lib/win64/lpsolve55j.dll
+    #       lib/junit.jar
+    #       lib/lpsolve55j.jar
+    #       lib/build
+    #       lib/build.bat
+    # We have 2 extra files in zip:
+    #       lp_solve_5.5_java/src/java/Perf.java
+    #       lp_solve_5.5_java/src/java/IsolatedTest.java
+    - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_java.zip
+      run: |
+        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_java.zip"
+
+        cd $env:GITHUB_WORKSPACE/extra
+
+        # TODO, this could probably be done with .gitattributes
+        echo "Fixing newlines of Unix scripts"
+        $scriptFiles=@("lp_solve_5.5_java/demo/build", "lp_solve_5.5_java/demo/run_demo", "lp_solve_5.5_java/demo/run_unittests", "lp_solve_5.5_java/src/java/lpsolve/build")
+        foreach ($f in $scriptFiles) {
+          (Get-Content $f -Raw).Replace("`r`n","`n") | Set-Content $f -NoNewLine -Force
+        }
+
+        echo "Packaging files from $PWD"
+        7z a -tzip -bso0 -bsp0 -r $zipPath `
+          lp_solve_5.5_java/demo `
+          lp_solve_5.5_java/demo2 `
+          lp_solve_5.5_java/docs `
+          lp_solve_5.5_java/src `
+          lp_solve_5.5_java/CHANGES.txt `
+          lp_solve_5.5_java/LGPL `
+          lp_solve_5.5_java/README.html `
+          '-x!lp_solve_5.5_java/demo/*.class' `
+          '-x!lp_solve_5.5_java/demo/*.log' `
+          '-x!lp_solve_5.5_java/demo/lpsolve' `
+          '-x!lp_solve_5.5_java/src/java/*.class' `
+          '-x!model.lp'
+
+    - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_MSF_source.zip
+      run: |
+        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_MSF_source.zip"
+
+        cd $env:GITHUB_WORKSPACE/extra/MSF
+        echo "Packaging files from $PWD"
+        7z a -tzip -bso0 -bsp0 -r $zipPath `
+          *
+
+    - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_vb.net.zip
+      run: |
+        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_vb.net.zip"
+
+        cd $env:GITHUB_WORKSPACE/extra/VB.NET
+        echo "Packaging files from $PWD"
+        7z a -tzip -bso0 -bsp0 $zipPath `
+          * `
+          '-x!app.config'
+
+    - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_vb.zip
+      run: |
+        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_vb.zip"
+
+        cd $env:GITHUB_WORKSPACE/extra/vb
+        echo "Packaging files from $PWD"
+        7z a -tzip -bso0 -bsp0 $zipPath `
+            Module1.bas `
+            lpsolve55.cls `
+            demo.vbp
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.job }}
+        compression-level: 0 # no compression - already compressed
+        retention-days: 1
+        path: |
+          *.zip
+          README.txt
+
+  tar-gz-on-linux:
+    needs: determine-version
+    runs-on: ubuntu-latest
+
+    env:
+      LPSOLVE_VERSION: ${{ needs.determine-version.outputs.LPSOLVE_VERSION }}
+      # TODO: decide what we want as root folder inside the *_source.tar.gz:
+      #       - lp_solve_5.5  like versions up to 5.5.2.11
+      #       - lp_solve      like in version 5.5.2.14
+      LPSOLVE_SOURCE_ROOT_FOLDER: lp_solve
+
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v5
+
+    - name: Install missing dependencies
+      run: |
+        set -v # echo commands
+
+        sudo apt-get update
+        sudo apt-get install -y \
+            dos2unix
+
+    - name: Fix EOL for Windows-related files
+      run: |
+        set -v # echo commands
+
+        find -name "*.bat" -exec unix2dos -q {} \;
+        find -name "*.sln" -exec unix2dos -q {} \;
+        find -name "*.vcproj" -exec unix2dos -q {} \;
+        find -name "*.vcxproj" -exec unix2dos -q {} \;
+        find -name "*.rc" -exec unix2dos -q {} \;
+        find -name "*.def" -exec unix2dos -q {} \;
+        find -name "*.net" -exec unix2dos -q {} \;
+
+    # Ensure this is done *before* adding any file in the workspace (like generated .tar.gz)
+    # otherwise they will end up in lp_solve_${{ env.LPSOLVE_VERSION }}_source.tar.gz file
+    - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_source.tar.gz
+      run: |
+        tar -czf ${GITHUB_WORKSPACE}/lp_solve_${LPSOLVE_VERSION}_source.tar.gz \
+            --transform "s,^,${LPSOLVE_SOURCE_ROOT_FOLDER}/," \
+            --exclude-vcs \
+            --exclude-vcs-ignores \
+            --exclude=output \
+            --exclude=xli \
+            --exclude=extra \
+            --exclude=.github \
+            --exclude=bfp/bfp_etaPFI \
+            --exclude=bfp/bfp_GLPK \
+            *
+
+    - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_bfp_*source.tar.gz
+      run: |
+        for i in etaPFI GLPK LUSOL
+        do
+          echo "Packaging lp_solve_${LPSOLVE_VERSION}_bfp_${i}_source.tar.gz"
+          tar -czf ${GITHUB_WORKSPACE}/lp_solve_${LPSOLVE_VERSION}_bfp_${i}_source.tar.gz \
+              --transform "s,^,${LPSOLVE_SOURCE_ROOT_FOLDER}/," \
+              --exclude-vcs-ignores \
+              bfp/bfp_${i} \
+              bfp/*.*
+        done
+
+    - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_xli_*source.tar.gz
+      run: |
+        for i in CPLEX LINDO LPFML MathProg MPS XPRESS
+        do
+          echo "Packaging lp_solve_${LPSOLVE_VERSION}_xli_${i}_source.tar.gz"
+          tar -czf ${GITHUB_WORKSPACE}/lp_solve_${LPSOLVE_VERSION}_xli_${i}_source.tar.gz \
+              --transform "s,^,${LPSOLVE_SOURCE_ROOT_FOLDER}/," \
+              --exclude-vcs-ignores \
+              xli/xli_${i} \
+              xli/*.*
+        done
+
+        # xli_DIMACS
+        echo "Packaging lp_solve_${LPSOLVE_VERSION}_xli_DIMACS_source.tar.gz"
+        tar -czf ${GITHUB_WORKSPACE}/lp_solve_${LPSOLVE_VERSION}_xli_DIMACS_source.tar.gz \
+            --transform "s,^extra/man,xli/xli_DIMACS," \
+            --transform "s,^,${LPSOLVE_SOURCE_ROOT_FOLDER}/," \
+            --exclude-vcs-ignores \
+            xli/xli_DIMACS \
+            xli/*.* \
+            extra/man/DIMACS_*.htm \
+            extra/man/dimacs_*.gif
+
+    - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_AMPL_source.tar.gz
+      run: |
+        tar -czf ${GITHUB_WORKSPACE}/lp_solve_${LPSOLVE_VERSION}_AMPL_source.tar.gz \
+            --transform "s,^extra/man,extra/AMPL/solvers/lpsolve," \
+            --transform "s,^,${LPSOLVE_SOURCE_ROOT_FOLDER}/," \
+            --exclude-vcs-ignores \
+            extra/AMPL/solvers \
+            extra/man/AMPL.htm
+
+    - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_{Euler,FreeMat,PHP,Python,Sysquake}_source.tar.gz
+      run: |
+        for i in Euler FreeMat PHP Python Sysquake
+        do
+          echo "Packaging lp_solve_${LPSOLVE_VERSION}_${i}_source.tar.gz"
+          tar -czf ${GITHUB_WORKSPACE}/lp_solve_${LPSOLVE_VERSION}_${i}_source.tar.gz \
+              --transform "s,^extra/man,extra/${i}," \
+              --transform "s,^,${LPSOLVE_SOURCE_ROOT_FOLDER}/," \
+              --exclude-vcs-ignores \
+              extra/${i} \
+              extra/man/${i}.htm
+        done
+
+    # TODO: zip here reproduces what was released with 5.5.2.14 which is missing files compared to 5.5.2.11:
+    #       extra/MATLAB/lpsolve/bin/win{32,64}/lp_explicit.lib
+    - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_MATLAB_source.tar.gz
+      run: |
+        tar -czf ${GITHUB_WORKSPACE}/lp_solve_${LPSOLVE_VERSION}_MATLAB_source.tar.gz \
+            --transform "s,^extra/man,extra/MATLAB/lpsolve," \
+            --transform "s,^,${LPSOLVE_SOURCE_ROOT_FOLDER}/," \
+            --exclude-vcs-ignores \
+            extra/MATLAB \
+            extra/man/MATLAB.htm
+
+    - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_octave_source.tar.gz
+      run: |
+        tar -czf ${GITHUB_WORKSPACE}/lp_solve_${LPSOLVE_VERSION}_octave_source.tar.gz \
+            --transform "s,^extra/man/octave.htm,extra/octave/lpsolve/Octave.htm," \
+            --transform "s,^,${LPSOLVE_SOURCE_ROOT_FOLDER}/," \
+            --exclude-vcs-ignores \
+            extra/octave \
+            extra/man/octave.htm
+
+    - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_OMATRIX_source.tar.gz
+      run: |
+        tar -czf ${GITHUB_WORKSPACE}/lp_solve_${LPSOLVE_VERSION}_OMATRIX_source.tar.gz \
+            --transform "s,^extra/man,extra/O-MATRIX/lpsolve," \
+            --transform "s,^,${LPSOLVE_SOURCE_ROOT_FOLDER}/," \
+            --exclude-vcs-ignores \
+            extra/O-MATRIX \
+            extra/man/O-Matrix.htm
+
+    - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_scilab_source.tar.gz
+      run: |
+        tar -czf ${GITHUB_WORKSPACE}/lp_solve_${LPSOLVE_VERSION}_scilab_source.tar.gz \
+            --transform "s,^extra/man/Scilab.htm,extra/scilab/lpsolve/man/scilab.htm," \
+            --transform "s,^,${LPSOLVE_SOURCE_ROOT_FOLDER}/," \
+            --exclude-vcs-ignores \
+            extra/scilab \
+            extra/man/Scilab.htm
+
+    - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_c.tar.gz
+      run: |
+        cd extra/c
+        tar -czf ${GITHUB_WORKSPACE}/lp_solve_${LPSOLVE_VERSION}_c.tar.gz \
+            --exclude-vcs-ignores \
+            --exclude=lp.lp \
+            *
+
+    - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_doc.tar.gz
+      run: |
+        cd extra/man
+        tar -czf ${GITHUB_WORKSPACE}/lp_solve_${LPSOLVE_VERSION}_doc.tar.gz \
+            --exclude-vcs-ignores \
+            --exclude=arv \
+            --exclude=Win32 \
+            --exclude=*.bat \
+            --exclude=BuildLog.htm \
+            --exclude=HTMLHelp.* \
+            --exclude=lp_solve.hh* \
+            --exclude=man.* \
+            --exclude=man0.* \
+            *
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.job }}
+        compression-level: 0 # no compression - already compressed
+        retention-days: 1
+        path: |
+          *.tar.gz
+
+  collect-all-release-files:
+    runs-on: ubuntu-latest
+    needs:
+      - build-win64
+      - build-win32
+      - zip-on-windows
+      - tar-gz-on-linux
+    steps:
+
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          # TODO: all files here reproduces what was released with 5.5.2.14
+          #       EXCEPT lp_solve_..._IDE_Setup.exe which we were not able to build automatically
+          #       Note that 5.5.2.14 is missing .zip/.tar.gz files compared to 5.5.2.11 as well
+          #       as missing files within its .zip/.tar.gz files as mentioned above.
+          name: release-files
+          delete-merged: true
+          compression-level: 0 # no compression - already compressed

--- a/.github/workflows/release-files.yaml
+++ b/.github/workflows/release-files.yaml
@@ -41,6 +41,7 @@ jobs:
     runs-on: windows-latest
 
     env:
+      LPSOLVE_WORKSPACE: ${{ github.workspace }}
       LPSOLVE_VERSION: ${{ needs.determine-version.outputs.LPSOLVE_VERSION }}
       LPSOLVE_PLATFORM: 'win64'
 
@@ -55,29 +56,7 @@ jobs:
         arch: ${{ env.LPSOLVE_PLATFORM }}
 
     - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_dev_${{ env.LPSOLVE_PLATFORM }}.zip
-      run: |
-        echo "Building lpsolve55 library for platform $env:LPSOLVE_PLATFORM"
-        pushd $env:GITHUB_WORKSPACE/lpsolve55
-        ./cvc8NOmsvcrt.bat
-        popd
-
-        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_dev_${{ env.LPSOLVE_PLATFORM }}.zip"
-
-        echo "Packaging files from $PWD"
-        7z a -tzip -bso0 -bsp0 $zipPath `
-          lp_Hash.h `
-          lp_lib.h `
-          lp_matrix.h `
-          lp_mipbb.h `
-          lp_SOS.h `
-          lp_types.h `
-          lp_utils.h
-
-        cd lpsolve55/bin/${{ env.LPSOLVE_PLATFORM }}
-        echo "Packaging files from $PWD"
-        7z a -tzip -bso0 -bsp0 $zipPath `
-          * `
-          '-x!lpsolve55.exp'
+      run: release_process/build-zip-dev_winXX.ps1
 
     # TODO: zip here reproduces what was released with 5.5.2.14 which is missing files compared to 5.5.2.11:
     #       bfp_etaPFI.dll
@@ -91,17 +70,7 @@ jobs:
     #       xli_MPS.dll
     #       xli_XPRESS.dll
     - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_exe_${{ env.LPSOLVE_PLATFORM }}.zip
-      run: |
-        echo "Building lp_solve.exe for platform $env:LPSOLVE_PLATFORM"
-        pushd $env:GITHUB_WORKSPACE/lp_solve
-        ./cvc8.bat
-        popd
-
-        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_exe_${{ env.LPSOLVE_PLATFORM }}.zip"
-
-        cd $env:GITHUB_WORKSPACE/lp_solve/bin/${{ env.LPSOLVE_PLATFORM }}
-        echo "Packaging files from $PWD"
-        7z a -tzip -bso0 -bsp0 $zipPath lp_solve.exe
+      run: release_process/build-zip-exe_winXX.ps1
 
     # TODO: zip here reproduces what was released with 5.5.2.14 which is missing files compared to 5.5.2.11:
     #       bin/win64/lp_explicit.lib
@@ -109,46 +78,17 @@ jobs:
     # If we decide not to ship those anymore, should we include Makefile.m instead like MATLAB.htm describes?
     # Maybe also the *.h and *.c that might be needed to build these within MATLAB?
     - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_MATLAB_exe_${{ env.LPSOLVE_PLATFORM }}.zip
-      run: |
-        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_MATLAB_exe_${{ env.LPSOLVE_PLATFORM }}.zip"
-
-        cd $env:GITHUB_WORKSPACE/extra/MATLAB/lpsolve
-        echo "Packaging files from $PWD"
-        7z a -tzip -bso0 -bsp0 $zipPath `
-            *.m `
-            changes `
-            README.txt `
-            '-x!Makefile.m'
-
-        cd $env:GITHUB_WORKSPACE/extra/man
-        echo "Packaging files from $PWD"
-        7z a -tzip -bso0 -bsp0 $zipPath `
-            MATLAB.htm
+      run: release_process/build-zip-MATLAB_exe_winXX.ps1
 
     # TODO: zip here reproduces what was released with 5.5.2.14 which is missing files compared to 5.5.2.11:
     #       bin/win64/sclpsolve.dll
     #       macros/lib
     # If we decide not to ship those anymore, should we include src/ folder?
     - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_scilab_exe_${{ env.LPSOLVE_PLATFORM }}.zip
-      run: |
-        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_scilab_exe_${{ env.LPSOLVE_PLATFORM }}.zip"
-
-        cd $env:GITHUB_WORKSPACE/extra/scilab/lpsolve
-        echo "Packaging files from $PWD"
-        7z a -tzip -bso0 -bsp0 -r $zipPath `
-            * `
-            '-x!src/'
-
-        cd $env:GITHUB_WORKSPACE/extra/man
-        echo "Packaging files from $PWD"
-        7z a -tzip -bso0 -bsp0 $zipPath `
-            Scilab.htm
+      run: release_process/build-zip-scilab_exe_winXX.ps1
 
     - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}.chm
-      run: |
-        cd $env:GITHUB_WORKSPACE/extra/man
-        ./gen.bat
-        cp *.chm $env:GITHUB_WORKSPACE
+      run: release_process/build-chm.ps1
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
@@ -165,6 +105,7 @@ jobs:
     runs-on: windows-latest
 
     env:
+      LPSOLVE_WORKSPACE: ${{ github.workspace }}
       LPSOLVE_VERSION: ${{ needs.determine-version.outputs.LPSOLVE_VERSION }}
       LPSOLVE_PLATFORM: 'win32'
 
@@ -179,29 +120,7 @@ jobs:
         arch: ${{ env.LPSOLVE_PLATFORM }}
 
     - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_dev_${{ env.LPSOLVE_PLATFORM }}.zip
-      run: |
-        echo "Building lpsolve55 library for platform $env:LPSOLVE_PLATFORM"
-        pushd $env:GITHUB_WORKSPACE/lpsolve55
-        ./cvc8NOmsvcrt.bat
-        popd
-
-        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_dev_${{ env.LPSOLVE_PLATFORM }}.zip"
-
-        echo "Packaging files from $PWD"
-        7z a -tzip -bso0 -bsp0 $zipPath `
-          lp_Hash.h `
-          lp_lib.h `
-          lp_matrix.h `
-          lp_mipbb.h `
-          lp_SOS.h `
-          lp_types.h `
-          lp_utils.h
-
-        cd lpsolve55/bin/${{ env.LPSOLVE_PLATFORM }}
-        echo "Packaging files from $PWD"
-        7z a -tzip -bso0 -bsp0 $zipPath `
-          * `
-          '-x!lpsolve55.exp'
+      run: release_process/build-zip-dev_winXX.ps1
 
     # TODO: zip here reproduces what was released with 5.5.2.14 which is missing files compared to 5.5.2.11:
     #       bfp_etaPFI.dll
@@ -217,34 +136,12 @@ jobs:
     #       xli_XPRESS.dll
     #       xli_ZIMPL.dll
     - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_exe_${{ env.LPSOLVE_PLATFORM }}.zip
-      run: |
-        echo "Building lp_solve.exe for platform $env:LPSOLVE_PLATFORM"
-        pushd $env:GITHUB_WORKSPACE/lp_solve
-        ./cvc8.bat
-        popd
-
-        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_exe_${{ env.LPSOLVE_PLATFORM }}.zip"
-
-        cd $env:GITHUB_WORKSPACE/lp_solve/bin/${{ env.LPSOLVE_PLATFORM }}
-        echo "Packaging files from $PWD"
-        7z a -tzip -bso0 -bsp0 $zipPath lp_solve.exe
+      run: release_process/build-zip-exe_winXX.ps1
 
     # TODO: zip here reproduces what was released with 5.5.2.14 which is missing files compared to 5.5.2.11:
     #       lpsolve.exe (which seems to be built from extra/AMPL/solvers/lpsolve/makefile5*.vc)
     - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_AMPL_exe_${{ env.LPSOLVE_PLATFORM }}.zip
-      run: |
-        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_AMPL_exe_${{ env.LPSOLVE_PLATFORM }}.zip"
-
-        cd $env:GITHUB_WORKSPACE/extra/AMPL/solvers/lpsolve
-        echo "Packaging files from $PWD"
-        7z a -tzip -bso0 -bsp0 $zipPath `
-            changes `
-            README
-
-        cd $env:GITHUB_WORKSPACE/extra/man
-        echo "Packaging files from $PWD"
-        7z a -tzip -bso0 -bsp0 $zipPath `
-            AMPL.htm
+      run: release_process/build-zip-AMPL_exe_winXX.ps1
 
     # TODO: zip here reproduces what was released with 5.5.2.14 which is missing files compared to 5.5.2.11:
     #       eulpsolve.dll(which seems to be built from extra/Euler/cvc.bat)
@@ -253,39 +150,12 @@ jobs:
     #       loadlpsolve70.en
     #       Test Problems.en
     - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_Euler_exe_${{ env.LPSOLVE_PLATFORM }}.zip
-      run: |
-        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_Euler_exe_${{ env.LPSOLVE_PLATFORM }}.zip"
-
-        cd $env:GITHUB_WORKSPACE/extra/Euler
-        echo "Packaging files from $PWD"
-        7z a -tzip -bso0 -bsp0 $zipPath `
-            changes `
-            *.en `
-            *.e `
-            README.txt
-
-        cd $env:GITHUB_WORKSPACE/extra/man
-        echo "Packaging files from $PWD"
-        7z a -tzip -bso0 -bsp0 $zipPath `
-            Euler.htm
+      run: release_process/build-zip-Euler_exe_winXX.ps1
 
     # TODO: zip here reproduces what was released with 5.5.2.14 which is missing files compared to 5.5.2.11:
     #       fmlpsolve.dll(which seems to be built from extra/FreeMat/cvc.bat)
     - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_FreeMat_exe_${{ env.LPSOLVE_PLATFORM }}.zip
-      run: |
-        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_FreeMat_exe_${{ env.LPSOLVE_PLATFORM }}.zip"
-
-        cd $env:GITHUB_WORKSPACE/extra/FreeMat
-        echo "Packaging files from $PWD"
-        7z a -tzip -bso0 -bsp0 $zipPath `
-            changes `
-            *.m `
-            README.txt
-
-        cd $env:GITHUB_WORKSPACE/extra/man
-        echo "Packaging files from $PWD"
-        7z a -tzip -bso0 -bsp0 $zipPath `
-            FreeMat.htm
+      run: release_process/build-zip-FreeMat_exe_winXX.ps1
 
     # TODO: zip here reproduces what was released with 5.5.2.14 which is missing files compared to 5.5.2.11:
     #       bin/win32/lp_explicit.lib
@@ -294,119 +164,40 @@ jobs:
     # If we decide not to ship those anymore, should we include Makefile.m instead like MATLAB.htm describes?
     # Maybe also the *.h and *.c that might be needed to build these within MATLAB?
     - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_MATLAB_exe_${{ env.LPSOLVE_PLATFORM }}.zip
-      run: |
-        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_MATLAB_exe_${{ env.LPSOLVE_PLATFORM }}.zip"
-
-        cd $env:GITHUB_WORKSPACE/extra/MATLAB/lpsolve
-        echo "Packaging files from $PWD"
-        7z a -tzip -bso0 -bsp0 $zipPath `
-            *.m `
-            changes `
-            README.txt `
-            '-x!Makefile.m'
-
-        cd $env:GITHUB_WORKSPACE/extra/man
-        echo "Packaging files from $PWD"
-        7z a -tzip -bso0 -bsp0 $zipPath `
-            MATLAB.htm
+      run: release_process/build-zip-MATLAB_exe_winXX.ps1
 
     # TODO: This only contains an HTML file, do we still want to release this?
     - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_MSF_exe_${{ env.LPSOLVE_PLATFORM }}.zip
-      run: |
-        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_MSF_exe_${{ env.LPSOLVE_PLATFORM }}.zip"
-
-        cd $env:GITHUB_WORKSPACE/extra/man
-        echo "Packaging files from $PWD"
-        7z a -tzip -bso0 -bsp0 $zipPath `
-            MSF.htm
+      run: release_process/build-zip-MSF_exe_winXX.ps1
 
     # TODO: zip here reproduces what was released with 5.5.2.14 which is missing files compared to 5.5.2.11:
     #       octlpsolve.oct
     - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_octave_exe_${{ env.LPSOLVE_PLATFORM }}.zip
-      run: |
-        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_octave_exe_${{ env.LPSOLVE_PLATFORM }}.zip"
-
-        cd $env:GITHUB_WORKSPACE/extra/octave/lpsolve
-        echo "Packaging files from $PWD"
-        7z a -tzip -bso0 -bsp0 -r $zipPath `
-            changes `
-            *.m `
-            README.txt
+      run: release_process/build-zip-octave_exe_winXX.ps1
 
     # TODO: zip here reproduces what was released with 5.5.2.14 which is missing files compared to 5.5.2.11:
     #       omlpsolve.dll (which seems built from cvc.bat)
     - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_OMATRIX_exe_${{ env.LPSOLVE_PLATFORM }}.zip
-      run: |
-        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_OMATRIX_exe_${{ env.LPSOLVE_PLATFORM }}.zip"
-
-        cd $env:GITHUB_WORKSPACE/extra/O-MATRIX/lpsolve
-        echo "Packaging files from $PWD"
-        7z a -tzip -bso0 -bsp0 -r $zipPath `
-            changes `
-            *.oms `
-            README.txt
-
-        cd $env:GITHUB_WORKSPACE/extra/man
-        echo "Packaging files from $PWD"
-        7z a -tzip -bso0 -bsp0 $zipPath `
-            O-Matrix.htm
+      run: release_process/build-zip-OMATRIX_exe_winXX.ps1
 
     # TODO: zip here reproduces what was released with 5.5.2.14 which is missing files compared to 5.5.2.11:
     #       php4/php_phplpsolve55.dll
     #       php5_2/php_phplpsolve55.dll
     #       php5_3/php_phplpsolve55.dll
     - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_PHP_exe_${{ env.LPSOLVE_PLATFORM }}.zip
-      run: |
-        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_PHP_exe_${{ env.LPSOLVE_PLATFORM }}.zip"
-
-        cd $env:GITHUB_WORKSPACE/extra/PHP
-        echo "Packaging files from $PWD"
-        7z a -tzip -bso0 -bsp0 -r $zipPath `
-            changes `
-            *.php `
-            README.txt
-
-        cd $env:GITHUB_WORKSPACE/extra/man
-        echo "Packaging files from $PWD"
-        7z a -tzip -bso0 -bsp0 $zipPath `
-            PHP.htm
+      run: release_process/build-zip-PHP_exe_winXX.ps1
 
     # TODO: zip here reproduces what was released with 5.5.2.14 which is missing files compared to 5.5.2.11:
     #       bin/win32/sclpsolve.dll
     #       macros/lib
     # If we decide not to ship those anymore, should we include src/ folder?
     - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_scilab_exe_${{ env.LPSOLVE_PLATFORM }}.zip
-      run: |
-        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_scilab_exe_${{ env.LPSOLVE_PLATFORM }}.zip"
-
-        cd $env:GITHUB_WORKSPACE/extra/scilab/lpsolve
-        echo "Packaging files from $PWD"
-        7z a -tzip -bso0 -bsp0 -r $zipPath `
-            * `
-            '-x!src/'
-
-        cd $env:GITHUB_WORKSPACE/extra/man
-        echo "Packaging files from $PWD"
-        7z a -tzip -bso0 -bsp0 $zipPath `
-            Scilab.htm
+      run: release_process/build-zip-scilab_exe_winXX.ps1
 
     # TODO: zip here reproduces what was released with 5.5.2.14 which is missing files compared to 5.5.2.11:
     #       sqlpsolveext.dll (seems to be built from cvc.bat)
     - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_Sysquake_exe_${{ env.LPSOLVE_PLATFORM }}.zip
-      run: |
-        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_Sysquake_exe_${{ env.LPSOLVE_PLATFORM }}.zip"
-
-        cd $env:GITHUB_WORKSPACE/extra/Sysquake
-        echo "Packaging files from $PWD"
-        7z a -tzip -bso0 -bsp0 -r $zipPath `
-            changes `
-            *.lml `
-            README.txt
-
-        cd $env:GITHUB_WORKSPACE/extra/man
-        echo "Packaging files from $PWD"
-        7z a -tzip -bso0 -bsp0 $zipPath `
-            Sysquake.htm
+      run: release_process/build-zip-Sysquake_exe_winXX.ps1
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
@@ -422,6 +213,7 @@ jobs:
     runs-on: windows-latest
 
     env:
+      LPSOLVE_WORKSPACE: ${{ github.workspace }}
       LPSOLVE_VERSION: ${{ needs.determine-version.outputs.LPSOLVE_VERSION }}
 
     steps:
@@ -430,68 +222,24 @@ jobs:
       uses: actions/checkout@v5
 
     - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_access.zip
-      run: |
-        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_access.zip"
-
-        cd $env:GITHUB_WORKSPACE/extra/Access
-        echo "Packaging files from $PWD"
-        7z a -tzip -bso0 -bsp0 $zipPath `
-          demo.mdb
+      run: release_process/build-zip-access.ps1
 
     # TODO: zip here reproduces what was released with 5.5.2.14 which is missing files compared to 5.5.2.11:
     #       lpsolve55COM.dll
     - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_COM.zip
-      run: |
-        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_COM.zip"
-
-        cd $env:GITHUB_WORKSPACE/extra/COM
-        echo "Packaging files from $PWD"
-        7z a -tzip -bso0 -bsp0 -r $zipPath `
-          * `
-          '-x!demo.vbg' `
-          '-x!lpsolve55ASP.cls'
+      run: release_process/build-zip-COM.ps1
 
     - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_cs.net.zip
-      run: |
-        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_cs.net.zip"
-
-        cd $env:GITHUB_WORKSPACE/extra/cs.net
-        echo "Packaging files from $PWD"
-        7z a -tzip -bso0 -bsp0 $zipPath `
-          * `
-          '-x!app.config'
+      run: release_process/build-zip-cs.net.ps1
 
     - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_Delphi.zip
-      run: |
-        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_Delphi.zip"
-
-        cd $env:GITHUB_WORKSPACE/extra/Delphi
-        echo "Packaging files from $PWD"
-        7z a -tzip -bso0 -bsp0 $zipPath `
-          cppc.bat `
-          demo.dpr `
-          lp.lp `
-          lpsolve.inc `
-          lpsolve.pas
+      run: release_process/build-zip-Delphi.ps1
 
     - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_excel.zip
-      run: |
-        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_excel.zip"
-
-        cd $env:GITHUB_WORKSPACE/extra/excel
-        echo "Packaging files from $PWD"
-        7z a -tzip -bso0 -bsp0 $zipPath `
-          demo.xls
+      run: release_process/build-zip-excel.ps1
 
     - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_IDE_source.zip
-      run: |
-        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_IDE_source.zip"
-
-        cd $env:GITHUB_WORKSPACE/extra/LPSolveIDE/IDE15
-        echo "Packaging files from $PWD"
-        7z a -tzip -bso0 -bsp0 $zipPath `
-          InnoSetup/L* `
-          *.*
+      run: release_process/build-zip-IDE_source.ps1
 
     # TODO: zip here reproduces what was released with 5.5.2.14 which is missing files compared to 5.5.2.11:
     #       lib/mac/build-osx
@@ -507,62 +255,16 @@ jobs:
     #       lp_solve_5.5_java/src/java/Perf.java
     #       lp_solve_5.5_java/src/java/IsolatedTest.java
     - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_java.zip
-      run: |
-        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_java.zip"
-
-        cd $env:GITHUB_WORKSPACE/extra
-
-        # TODO, this could probably be done with .gitattributes
-        echo "Fixing newlines of Unix scripts"
-        $scriptFiles=@("lp_solve_5.5_java/demo/build", "lp_solve_5.5_java/demo/run_demo", "lp_solve_5.5_java/demo/run_unittests", "lp_solve_5.5_java/src/java/lpsolve/build")
-        foreach ($f in $scriptFiles) {
-          (Get-Content $f -Raw).Replace("`r`n","`n") | Set-Content $f -NoNewLine -Force
-        }
-
-        echo "Packaging files from $PWD"
-        7z a -tzip -bso0 -bsp0 -r $zipPath `
-          lp_solve_5.5_java/demo `
-          lp_solve_5.5_java/demo2 `
-          lp_solve_5.5_java/docs `
-          lp_solve_5.5_java/src `
-          lp_solve_5.5_java/CHANGES.txt `
-          lp_solve_5.5_java/LGPL `
-          lp_solve_5.5_java/README.html `
-          '-x!lp_solve_5.5_java/demo/*.class' `
-          '-x!lp_solve_5.5_java/demo/*.log' `
-          '-x!lp_solve_5.5_java/demo/lpsolve' `
-          '-x!lp_solve_5.5_java/src/java/*.class' `
-          '-x!model.lp'
+      run: release_process/build-zip-java.ps1
 
     - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_MSF_source.zip
-      run: |
-        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_MSF_source.zip"
-
-        cd $env:GITHUB_WORKSPACE/extra/MSF
-        echo "Packaging files from $PWD"
-        7z a -tzip -bso0 -bsp0 -r $zipPath `
-          *
+      run: release_process/build-zip-MSF_source.ps1
 
     - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_vb.net.zip
-      run: |
-        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_vb.net.zip"
-
-        cd $env:GITHUB_WORKSPACE/extra/VB.NET
-        echo "Packaging files from $PWD"
-        7z a -tzip -bso0 -bsp0 $zipPath `
-          * `
-          '-x!app.config'
+      run: release_process/build-zip-vb.net.ps1
 
     - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_vb.zip
-      run: |
-        $zipPath = "$env:GITHUB_WORKSPACE/lp_solve_${{ env.LPSOLVE_VERSION }}_vb.zip"
-
-        cd $env:GITHUB_WORKSPACE/extra/vb
-        echo "Packaging files from $PWD"
-        7z a -tzip -bso0 -bsp0 $zipPath `
-            Module1.bas `
-            lpsolve55.cls `
-            demo.vbp
+      run: release_process/build-zip-vb.ps1
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
@@ -579,6 +281,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
+      LPSOLVE_WORKSPACE: ${{ github.workspace }}
       LPSOLVE_VERSION: ${{ needs.determine-version.outputs.LPSOLVE_VERSION }}
       # TODO: decide what we want as root folder inside the *_source.tar.gz:
       #       - lp_solve_5.5  like versions up to 5.5.2.11
@@ -613,136 +316,39 @@ jobs:
     # Ensure this is done *before* adding any file in the workspace (like generated .tar.gz)
     # otherwise they will end up in lp_solve_${{ env.LPSOLVE_VERSION }}_source.tar.gz file
     - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_source.tar.gz
-      run: |
-        tar -czf ${GITHUB_WORKSPACE}/lp_solve_${LPSOLVE_VERSION}_source.tar.gz \
-            --transform "s,^,${LPSOLVE_SOURCE_ROOT_FOLDER}/," \
-            --exclude-vcs \
-            --exclude-vcs-ignores \
-            --exclude=output \
-            --exclude=xli \
-            --exclude=extra \
-            --exclude=.github \
-            --exclude=bfp/bfp_etaPFI \
-            --exclude=bfp/bfp_GLPK \
-            *
+      run: ./release_process/build-targz-source.sh
 
-    - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_bfp_*source.tar.gz
-      run: |
-        for i in etaPFI GLPK LUSOL
-        do
-          echo "Packaging lp_solve_${LPSOLVE_VERSION}_bfp_${i}_source.tar.gz"
-          tar -czf ${GITHUB_WORKSPACE}/lp_solve_${LPSOLVE_VERSION}_bfp_${i}_source.tar.gz \
-              --transform "s,^,${LPSOLVE_SOURCE_ROOT_FOLDER}/," \
-              --exclude-vcs-ignores \
-              bfp/bfp_${i} \
-              bfp/*.*
-        done
+    - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_bfp_*_source.tar.gz
+      run: ./release_process/build-targz-bfp_XX_source.sh
 
-    - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_xli_*source.tar.gz
-      run: |
-        for i in CPLEX LINDO LPFML MathProg MPS XPRESS
-        do
-          echo "Packaging lp_solve_${LPSOLVE_VERSION}_xli_${i}_source.tar.gz"
-          tar -czf ${GITHUB_WORKSPACE}/lp_solve_${LPSOLVE_VERSION}_xli_${i}_source.tar.gz \
-              --transform "s,^,${LPSOLVE_SOURCE_ROOT_FOLDER}/," \
-              --exclude-vcs-ignores \
-              xli/xli_${i} \
-              xli/*.*
-        done
-
-        # xli_DIMACS
-        echo "Packaging lp_solve_${LPSOLVE_VERSION}_xli_DIMACS_source.tar.gz"
-        tar -czf ${GITHUB_WORKSPACE}/lp_solve_${LPSOLVE_VERSION}_xli_DIMACS_source.tar.gz \
-            --transform "s,^extra/man,xli/xli_DIMACS," \
-            --transform "s,^,${LPSOLVE_SOURCE_ROOT_FOLDER}/," \
-            --exclude-vcs-ignores \
-            xli/xli_DIMACS \
-            xli/*.* \
-            extra/man/DIMACS_*.htm \
-            extra/man/dimacs_*.gif
+    - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_xli_*_source.tar.gz
+      run: ./release_process/build-targz-xli_XX_source.sh
 
     - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_AMPL_source.tar.gz
-      run: |
-        tar -czf ${GITHUB_WORKSPACE}/lp_solve_${LPSOLVE_VERSION}_AMPL_source.tar.gz \
-            --transform "s,^extra/man,extra/AMPL/solvers/lpsolve," \
-            --transform "s,^,${LPSOLVE_SOURCE_ROOT_FOLDER}/," \
-            --exclude-vcs-ignores \
-            extra/AMPL/solvers \
-            extra/man/AMPL.htm
+      run: ./release_process/build-targz-AMPL_source.sh
 
     - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_{Euler,FreeMat,PHP,Python,Sysquake}_source.tar.gz
-      run: |
-        for i in Euler FreeMat PHP Python Sysquake
-        do
-          echo "Packaging lp_solve_${LPSOLVE_VERSION}_${i}_source.tar.gz"
-          tar -czf ${GITHUB_WORKSPACE}/lp_solve_${LPSOLVE_VERSION}_${i}_source.tar.gz \
-              --transform "s,^extra/man,extra/${i}," \
-              --transform "s,^,${LPSOLVE_SOURCE_ROOT_FOLDER}/," \
-              --exclude-vcs-ignores \
-              extra/${i} \
-              extra/man/${i}.htm
-        done
+      run: ./release_process/build-targz-manyextras_source.sh
 
     # TODO: zip here reproduces what was released with 5.5.2.14 which is missing files compared to 5.5.2.11:
     #       extra/MATLAB/lpsolve/bin/win{32,64}/lp_explicit.lib
     - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_MATLAB_source.tar.gz
-      run: |
-        tar -czf ${GITHUB_WORKSPACE}/lp_solve_${LPSOLVE_VERSION}_MATLAB_source.tar.gz \
-            --transform "s,^extra/man,extra/MATLAB/lpsolve," \
-            --transform "s,^,${LPSOLVE_SOURCE_ROOT_FOLDER}/," \
-            --exclude-vcs-ignores \
-            extra/MATLAB \
-            extra/man/MATLAB.htm
+      run: ./release_process/build-targz-MATLAB_source.sh
 
     - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_octave_source.tar.gz
-      run: |
-        tar -czf ${GITHUB_WORKSPACE}/lp_solve_${LPSOLVE_VERSION}_octave_source.tar.gz \
-            --transform "s,^extra/man/octave.htm,extra/octave/lpsolve/Octave.htm," \
-            --transform "s,^,${LPSOLVE_SOURCE_ROOT_FOLDER}/," \
-            --exclude-vcs-ignores \
-            extra/octave \
-            extra/man/octave.htm
+      run: ./release_process/build-targz-octave_source.sh
 
     - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_OMATRIX_source.tar.gz
-      run: |
-        tar -czf ${GITHUB_WORKSPACE}/lp_solve_${LPSOLVE_VERSION}_OMATRIX_source.tar.gz \
-            --transform "s,^extra/man,extra/O-MATRIX/lpsolve," \
-            --transform "s,^,${LPSOLVE_SOURCE_ROOT_FOLDER}/," \
-            --exclude-vcs-ignores \
-            extra/O-MATRIX \
-            extra/man/O-Matrix.htm
+      run: ./release_process/build-targz-OMATRIX_source.sh
 
     - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_scilab_source.tar.gz
-      run: |
-        tar -czf ${GITHUB_WORKSPACE}/lp_solve_${LPSOLVE_VERSION}_scilab_source.tar.gz \
-            --transform "s,^extra/man/Scilab.htm,extra/scilab/lpsolve/man/scilab.htm," \
-            --transform "s,^,${LPSOLVE_SOURCE_ROOT_FOLDER}/," \
-            --exclude-vcs-ignores \
-            extra/scilab \
-            extra/man/Scilab.htm
+      run: ./release_process/build-targz-scilab_source.sh
 
     - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_c.tar.gz
-      run: |
-        cd extra/c
-        tar -czf ${GITHUB_WORKSPACE}/lp_solve_${LPSOLVE_VERSION}_c.tar.gz \
-            --exclude-vcs-ignores \
-            --exclude=lp.lp \
-            *
+      run: ./release_process/build-targz-c.sh
 
     - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_doc.tar.gz
-      run: |
-        cd extra/man
-        tar -czf ${GITHUB_WORKSPACE}/lp_solve_${LPSOLVE_VERSION}_doc.tar.gz \
-            --exclude-vcs-ignores \
-            --exclude=arv \
-            --exclude=Win32 \
-            --exclude=*.bat \
-            --exclude=BuildLog.htm \
-            --exclude=HTMLHelp.* \
-            --exclude=lp_solve.hh* \
-            --exclude=man.* \
-            --exclude=man0.* \
-            *
+      run: ./release_process/build-targz-doc.sh
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -369,3 +369,6 @@ extra/man/.gitignore
 distriball.bat
 **/distribsrc.txt
 distrib/
+
+# build artifacts
+lpsolve55/RCa*

--- a/extra/man/gen.bat
+++ b/extra/man/gen.bat
@@ -1,2 +1,5 @@
 @echo off
+:: https://stackoverflow.com/a/39040033/197371
+:: exit code 1 is success exit code 0 is failure
 hhc.exe lp_solve.hhp
+if not errorlevel 1 exit /B 1

--- a/release_process/.editorconfig
+++ b/release_process/.editorconfig
@@ -1,0 +1,7 @@
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true

--- a/release_process/.gitattributes
+++ b/release_process/.gitattributes
@@ -1,0 +1,2 @@
+*.sh text eol=lf
+*.ps1 text eol=lf

--- a/release_process/build-chm.ps1
+++ b/release_process/build-chm.ps1
@@ -1,0 +1,7 @@
+. $PSScriptRoot/check_env_vars.ps1
+$requiredEnvVars = @("LPSOLVE_WORKSPACE")
+Assert-EnvironmentVariablesAreNotEmpty $requiredEnvVars
+
+cd ${env:LPSOLVE_WORKSPACE}/extra/man
+./gen.bat
+cp *.chm ${env:LPSOLVE_WORKSPACE}

--- a/release_process/build-targz-AMPL_source.sh
+++ b/release_process/build-targz-AMPL_source.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+. $(dirname "$0")/check_env_vars.sh
+requiredEnvVars=("LPSOLVE_WORKSPACE" "LPSOLVE_VERSION" "LPSOLVE_SOURCE_ROOT_FOLDER")
+assertEnvironmentVariablesAreNotEmpty "${requiredEnvVars[@]}"
+
+cd ${LPSOLVE_WORKSPACE}
+tar -czf ${LPSOLVE_WORKSPACE}/lp_solve_${LPSOLVE_VERSION}_AMPL_source.tar.gz \
+    --transform "s,^extra/man,extra/AMPL/solvers/lpsolve," \
+    --transform "s,^,${LPSOLVE_SOURCE_ROOT_FOLDER}/," \
+    --exclude-vcs-ignores \
+    extra/AMPL/solvers \
+    extra/man/AMPL.htm

--- a/release_process/build-targz-MATLAB_source.sh
+++ b/release_process/build-targz-MATLAB_source.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+. $(dirname "$0")/check_env_vars.sh
+requiredEnvVars=("LPSOLVE_WORKSPACE" "LPSOLVE_VERSION" "LPSOLVE_SOURCE_ROOT_FOLDER")
+assertEnvironmentVariablesAreNotEmpty "${requiredEnvVars[@]}"
+
+cd ${LPSOLVE_WORKSPACE}
+tar -czf ${LPSOLVE_WORKSPACE}/lp_solve_${LPSOLVE_VERSION}_MATLAB_source.tar.gz \
+    --transform "s,^extra/man,extra/MATLAB/lpsolve," \
+    --transform "s,^,${LPSOLVE_SOURCE_ROOT_FOLDER}/," \
+    --exclude-vcs-ignores \
+    extra/MATLAB \
+    extra/man/MATLAB.htm

--- a/release_process/build-targz-OMATRIX_source.sh
+++ b/release_process/build-targz-OMATRIX_source.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+. $(dirname "$0")/check_env_vars.sh
+requiredEnvVars=("LPSOLVE_WORKSPACE" "LPSOLVE_VERSION" "LPSOLVE_SOURCE_ROOT_FOLDER")
+assertEnvironmentVariablesAreNotEmpty "${requiredEnvVars[@]}"
+
+cd ${LPSOLVE_WORKSPACE}
+tar -czf ${LPSOLVE_WORKSPACE}/lp_solve_${LPSOLVE_VERSION}_OMATRIX_source.tar.gz \
+    --transform "s,^extra/man,extra/O-MATRIX/lpsolve," \
+    --transform "s,^,${LPSOLVE_SOURCE_ROOT_FOLDER}/," \
+    --exclude-vcs-ignores \
+    extra/O-MATRIX \
+    extra/man/O-Matrix.htm

--- a/release_process/build-targz-bfp_XX_source.sh
+++ b/release_process/build-targz-bfp_XX_source.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+. $(dirname "$0")/check_env_vars.sh
+requiredEnvVars=("LPSOLVE_WORKSPACE" "LPSOLVE_VERSION" "LPSOLVE_SOURCE_ROOT_FOLDER")
+assertEnvironmentVariablesAreNotEmpty "${requiredEnvVars[@]}"
+
+cd ${LPSOLVE_WORKSPACE}
+for folder in bfp_etaPFI bfp_GLPK bfp_LUSOL;
+do
+    echo "Packaging lp_solve_${LPSOLVE_VERSION}_${folder}_source.tar.gz"
+    tar -czf ${LPSOLVE_WORKSPACE}/lp_solve_${LPSOLVE_VERSION}_${folder}_source.tar.gz \
+        --transform "s,^,${LPSOLVE_SOURCE_ROOT_FOLDER}/," \
+        --exclude-vcs-ignores \
+        bfp/${folder} \
+        bfp/*.*
+done

--- a/release_process/build-targz-c.sh
+++ b/release_process/build-targz-c.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+. $(dirname "$0")/check_env_vars.sh
+requiredEnvVars=("LPSOLVE_WORKSPACE" "LPSOLVE_VERSION")
+assertEnvironmentVariablesAreNotEmpty "${requiredEnvVars[@]}"
+
+cd ${LPSOLVE_WORKSPACE}
+cd extra/c
+tar -czf ${LPSOLVE_WORKSPACE}/lp_solve_${LPSOLVE_VERSION}_c.tar.gz \
+    --exclude-vcs-ignores \
+    --exclude=lp.lp \
+    *

--- a/release_process/build-targz-doc.sh
+++ b/release_process/build-targz-doc.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+. $(dirname "$0")/check_env_vars.sh
+requiredEnvVars=("LPSOLVE_WORKSPACE" "LPSOLVE_VERSION")
+assertEnvironmentVariablesAreNotEmpty "${requiredEnvVars[@]}"
+
+cd ${LPSOLVE_WORKSPACE}
+cd extra/man
+tar -czf ${LPSOLVE_WORKSPACE}/lp_solve_${LPSOLVE_VERSION}_doc.tar.gz \
+    --exclude-vcs-ignores \
+    --exclude=arv \
+    --exclude=Win32 \
+    --exclude=*.bat \
+    --exclude=BuildLog.htm \
+    --exclude=HTMLHelp.* \
+    --exclude=lp_solve.hh* \
+    --exclude=man.* \
+    --exclude=man0.* \
+    *

--- a/release_process/build-targz-manyextras_source.sh
+++ b/release_process/build-targz-manyextras_source.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+. $(dirname "$0")/check_env_vars.sh
+requiredEnvVars=("LPSOLVE_WORKSPACE" "LPSOLVE_VERSION" "LPSOLVE_SOURCE_ROOT_FOLDER")
+assertEnvironmentVariablesAreNotEmpty "${requiredEnvVars[@]}"
+
+cd ${LPSOLVE_WORKSPACE}
+for folder in Euler FreeMat PHP Python Sysquake ;
+do
+    echo "Packaging lp_solve_${LPSOLVE_VERSION}_${folder}_source.tar.gz"
+    tar -czf ${LPSOLVE_WORKSPACE}/lp_solve_${LPSOLVE_VERSION}_${folder}_source.tar.gz \
+        --transform "s,^extra/man,extra/${folder}," \
+        --transform "s,^,${LPSOLVE_SOURCE_ROOT_FOLDER}/," \
+        --exclude-vcs-ignores \
+        extra/${folder} \
+        extra/man/${folder}.htm
+done

--- a/release_process/build-targz-octave_source.sh
+++ b/release_process/build-targz-octave_source.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+. $(dirname "$0")/check_env_vars.sh
+requiredEnvVars=("LPSOLVE_WORKSPACE" "LPSOLVE_VERSION" "LPSOLVE_SOURCE_ROOT_FOLDER")
+assertEnvironmentVariablesAreNotEmpty "${requiredEnvVars[@]}"
+
+cd ${LPSOLVE_WORKSPACE}
+tar -czf ${LPSOLVE_WORKSPACE}/lp_solve_${LPSOLVE_VERSION}_octave_source.tar.gz \
+    --transform "s,^extra/man/octave.htm,extra/octave/lpsolve/Octave.htm," \
+    --transform "s,^,${LPSOLVE_SOURCE_ROOT_FOLDER}/," \
+    --exclude-vcs-ignores \
+    extra/octave \
+    extra/man/octave.htm

--- a/release_process/build-targz-scilab_source.sh
+++ b/release_process/build-targz-scilab_source.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+. $(dirname "$0")/check_env_vars.sh
+requiredEnvVars=("LPSOLVE_WORKSPACE" "LPSOLVE_VERSION" "LPSOLVE_SOURCE_ROOT_FOLDER")
+assertEnvironmentVariablesAreNotEmpty "${requiredEnvVars[@]}"
+
+cd ${LPSOLVE_WORKSPACE}
+tar -czf ${LPSOLVE_WORKSPACE}/lp_solve_${LPSOLVE_VERSION}_scilab_source.tar.gz \
+    --transform "s,^extra/man/Scilab.htm,extra/scilab/lpsolve/man/scilab.htm," \
+    --transform "s,^,${LPSOLVE_SOURCE_ROOT_FOLDER}/," \
+    --exclude-vcs-ignores \
+    extra/scilab \
+    extra/man/Scilab.htm

--- a/release_process/build-targz-source.sh
+++ b/release_process/build-targz-source.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+. $(dirname "$0")/check_env_vars.sh
+requiredEnvVars=("LPSOLVE_WORKSPACE" "LPSOLVE_VERSION" "LPSOLVE_SOURCE_ROOT_FOLDER")
+assertEnvironmentVariablesAreNotEmpty "${requiredEnvVars[@]}"
+
+cd ${LPSOLVE_WORKSPACE}
+tar -czf ${LPSOLVE_WORKSPACE}/lp_solve_${LPSOLVE_VERSION}_source.tar.gz \
+    --transform "s,^,${LPSOLVE_SOURCE_ROOT_FOLDER}/," \
+    --exclude-vcs \
+    --exclude-vcs-ignores \
+    --exclude=output \
+    --exclude=xli \
+    --exclude=extra \
+    --exclude=.github \
+    --exclude=bfp/bfp_etaPFI \
+    --exclude=bfp/bfp_GLPK \
+    *

--- a/release_process/build-targz-xli_XX_source.sh
+++ b/release_process/build-targz-xli_XX_source.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+
+. $(dirname "$0")/check_env_vars.sh
+requiredEnvVars=("LPSOLVE_WORKSPACE" "LPSOLVE_VERSION" "LPSOLVE_SOURCE_ROOT_FOLDER")
+assertEnvironmentVariablesAreNotEmpty "${requiredEnvVars[@]}"
+
+cd ${LPSOLVE_WORKSPACE}
+
+for folder in xli_CPLEX xli_LINDO xli_LPFML xli_MathProg xli_MPS xli_XPRESS ;
+do
+    echo "Packaging lp_solve_${LPSOLVE_VERSION}_${folder}_source.tar.gz"
+    tar -czf ${LPSOLVE_WORKSPACE}/lp_solve_${LPSOLVE_VERSION}_${folder}_source.tar.gz \
+        --transform "s,^,${LPSOLVE_SOURCE_ROOT_FOLDER}/," \
+        --exclude-vcs-ignores \
+        xli/${folder} \
+        xli/*.*
+done
+
+echo "Packaging lp_solve_${LPSOLVE_VERSION}_xli_DIMACS_source.tar.gz"
+tar -czf ${LPSOLVE_WORKSPACE}/lp_solve_${LPSOLVE_VERSION}_xli_DIMACS_source.tar.gz \
+    --transform "s,^extra/man,xli/xli_DIMACS," \
+    --transform "s,^,${LPSOLVE_SOURCE_ROOT_FOLDER}/," \
+    --exclude-vcs-ignores \
+    xli/xli_DIMACS \
+    xli/*.* \
+    extra/man/DIMACS_*.htm \
+    extra/man/dimacs_*.gif

--- a/release_process/build-zip-AMPL_exe_winXX.ps1
+++ b/release_process/build-zip-AMPL_exe_winXX.ps1
@@ -1,0 +1,16 @@
+. $PSScriptRoot/check_env_vars.ps1
+$requiredEnvVars = @("LPSOLVE_WORKSPACE", "LPSOLVE_VERSION", "LPSOLVE_PLATFORM")
+Assert-EnvironmentVariablesAreNotEmpty $requiredEnvVars
+
+$zipPath = "${env:LPSOLVE_WORKSPACE}/lp_solve_${env:LPSOLVE_VERSION}_AMPL_exe_${env:LPSOLVE_PLATFORM}.zip"
+
+cd ${env:LPSOLVE_WORKSPACE}/extra/AMPL/solvers/lpsolve
+echo "Packaging files from ${PWD} into ${zipPath}"
+7z a -tzip -bso0 -bsp0 $zipPath `
+    changes `
+    README
+
+cd ${env:LPSOLVE_WORKSPACE}/extra/man
+echo "Packaging files from ${PWD} into ${zipPath}"
+7z a -tzip -bso0 -bsp0 $zipPath `
+    AMPL.htm

--- a/release_process/build-zip-COM.ps1
+++ b/release_process/build-zip-COM.ps1
@@ -1,0 +1,12 @@
+. $PSScriptRoot/check_env_vars.ps1
+$requiredEnvVars = @("LPSOLVE_WORKSPACE", "LPSOLVE_VERSION")
+Assert-EnvironmentVariablesAreNotEmpty $requiredEnvVars
+
+$zipPath = "${env:LPSOLVE_WORKSPACE}/lp_solve_${env:LPSOLVE_VERSION}_COM.zip"
+
+cd ${env:LPSOLVE_WORKSPACE}/extra/COM
+echo "Packaging files from ${PWD} into ${zipPath}"
+7z a -tzip -bso0 -bsp0 -r $zipPath `
+    * `
+    '-x!demo.vbg' `
+    '-x!lpsolve55ASP.cls'

--- a/release_process/build-zip-Delphi.ps1
+++ b/release_process/build-zip-Delphi.ps1
@@ -1,0 +1,14 @@
+. $PSScriptRoot/check_env_vars.ps1
+$requiredEnvVars = @("LPSOLVE_WORKSPACE", "LPSOLVE_VERSION")
+Assert-EnvironmentVariablesAreNotEmpty $requiredEnvVars
+
+$zipPath = "${env:LPSOLVE_WORKSPACE}/lp_solve_${env:LPSOLVE_VERSION}_Delphi.zip"
+
+cd ${env:LPSOLVE_WORKSPACE}/extra/Delphi
+echo "Packaging files from ${PWD} into ${zipPath}"
+7z a -tzip -bso0 -bsp0 $zipPath `
+    cppc.bat `
+    demo.dpr `
+    lp.lp `
+    lpsolve.inc `
+    lpsolve.pas

--- a/release_process/build-zip-Euler_exe_winXX.ps1
+++ b/release_process/build-zip-Euler_exe_winXX.ps1
@@ -1,0 +1,18 @@
+. $PSScriptRoot/check_env_vars.ps1
+$requiredEnvVars = @("LPSOLVE_WORKSPACE", "LPSOLVE_VERSION", "LPSOLVE_PLATFORM")
+Assert-EnvironmentVariablesAreNotEmpty $requiredEnvVars
+
+$zipPath = "${env:LPSOLVE_WORKSPACE}/lp_solve_${env:LPSOLVE_VERSION}_Euler_exe_${env:LPSOLVE_PLATFORM}.zip"
+
+cd ${env:LPSOLVE_WORKSPACE}/extra/Euler
+echo "Packaging files from ${PWD} into ${zipPath}"
+7z a -tzip -bso0 -bsp0 $zipPath `
+    changes `
+    *.en `
+    *.e `
+    README.txt
+
+cd ${env:LPSOLVE_WORKSPACE}/extra/man
+echo "Packaging files from ${PWD} into ${zipPath}"
+7z a -tzip -bso0 -bsp0 $zipPath `
+    Euler.htm

--- a/release_process/build-zip-FreeMat_exe_winXX.ps1
+++ b/release_process/build-zip-FreeMat_exe_winXX.ps1
@@ -1,0 +1,17 @@
+. $PSScriptRoot/check_env_vars.ps1
+$requiredEnvVars = @("LPSOLVE_WORKSPACE", "LPSOLVE_VERSION", "LPSOLVE_PLATFORM")
+Assert-EnvironmentVariablesAreNotEmpty $requiredEnvVars
+
+$zipPath = "${env:LPSOLVE_WORKSPACE}/lp_solve_${env:LPSOLVE_VERSION}_FreeMat_exe_${env:LPSOLVE_PLATFORM}.zip"
+
+cd ${env:LPSOLVE_WORKSPACE}/extra/FreeMat
+echo "Packaging files from ${PWD} into ${zipPath}"
+7z a -tzip -bso0 -bsp0 $zipPath `
+    changes `
+    *.m `
+    README.txt
+
+cd ${env:LPSOLVE_WORKSPACE}/extra/man
+echo "Packaging files from ${PWD} into ${zipPath}"
+7z a -tzip -bso0 -bsp0 $zipPath `
+    FreeMat.htm

--- a/release_process/build-zip-IDE_source.ps1
+++ b/release_process/build-zip-IDE_source.ps1
@@ -1,0 +1,11 @@
+. $PSScriptRoot/check_env_vars.ps1
+$requiredEnvVars = @("LPSOLVE_WORKSPACE", "LPSOLVE_VERSION")
+Assert-EnvironmentVariablesAreNotEmpty $requiredEnvVars
+
+$zipPath = "${env:LPSOLVE_WORKSPACE}/lp_solve_${env:LPSOLVE_VERSION}_IDE_source.zip"
+
+cd ${env:LPSOLVE_WORKSPACE}/extra/LPSolveIDE/IDE15
+echo "Packaging files from ${PWD} into ${zipPath}"
+7z a -tzip -bso0 -bsp0 $zipPath `
+    InnoSetup/L* `
+    *.*

--- a/release_process/build-zip-MATLAB_exe_winXX.ps1
+++ b/release_process/build-zip-MATLAB_exe_winXX.ps1
@@ -1,0 +1,18 @@
+. $PSScriptRoot/check_env_vars.ps1
+$requiredEnvVars = @("LPSOLVE_WORKSPACE", "LPSOLVE_VERSION", "LPSOLVE_PLATFORM")
+Assert-EnvironmentVariablesAreNotEmpty $requiredEnvVars
+
+$zipPath = "${env:LPSOLVE_WORKSPACE}/lp_solve_${env:LPSOLVE_VERSION}_MATLAB_exe_${env:LPSOLVE_PLATFORM}.zip"
+
+cd ${env:LPSOLVE_WORKSPACE}/extra/MATLAB/lpsolve
+echo "Packaging files from ${PWD} into ${zipPath}"
+7z a -tzip -bso0 -bsp0 $zipPath `
+    *.m `
+    changes `
+    README.txt `
+    '-x!Makefile.m'
+
+cd ${env:LPSOLVE_WORKSPACE}/extra/man
+echo "Packaging files from ${PWD} into ${zipPath}"
+7z a -tzip -bso0 -bsp0 $zipPath `
+    MATLAB.htm

--- a/release_process/build-zip-MSF_exe_winXX.ps1
+++ b/release_process/build-zip-MSF_exe_winXX.ps1
@@ -1,0 +1,10 @@
+. $PSScriptRoot/check_env_vars.ps1
+$requiredEnvVars = @("LPSOLVE_WORKSPACE", "LPSOLVE_VERSION", "LPSOLVE_PLATFORM")
+Assert-EnvironmentVariablesAreNotEmpty $requiredEnvVars
+
+$zipPath = "${env:LPSOLVE_WORKSPACE}/lp_solve_${env:LPSOLVE_VERSION}_MSF_exe_${env:LPSOLVE_PLATFORM}.zip"
+
+cd ${env:LPSOLVE_WORKSPACE}/extra/man
+echo "Packaging files from ${PWD} into ${zipPath}"
+7z a -tzip -bso0 -bsp0 $zipPath `
+    MSF.htm

--- a/release_process/build-zip-MSF_source.ps1
+++ b/release_process/build-zip-MSF_source.ps1
@@ -1,0 +1,10 @@
+. $PSScriptRoot/check_env_vars.ps1
+$requiredEnvVars = @("LPSOLVE_WORKSPACE", "LPSOLVE_VERSION")
+Assert-EnvironmentVariablesAreNotEmpty $requiredEnvVars
+
+$zipPath = "${env:LPSOLVE_WORKSPACE}/lp_solve_${env:LPSOLVE_VERSION}_MSF_source.zip"
+
+cd ${env:LPSOLVE_WORKSPACE}/extra/MSF
+echo "Packaging files from ${PWD} into ${zipPath}"
+7z a -tzip -bso0 -bsp0 -r $zipPath `
+    *

--- a/release_process/build-zip-OMATRIX_exe_winXX.ps1
+++ b/release_process/build-zip-OMATRIX_exe_winXX.ps1
@@ -1,0 +1,17 @@
+. $PSScriptRoot/check_env_vars.ps1
+$requiredEnvVars = @("LPSOLVE_WORKSPACE", "LPSOLVE_VERSION", "LPSOLVE_PLATFORM")
+Assert-EnvironmentVariablesAreNotEmpty $requiredEnvVars
+
+$zipPath = "${env:LPSOLVE_WORKSPACE}/lp_solve_${env:LPSOLVE_VERSION}_OMATRIX_exe_${env:LPSOLVE_PLATFORM}.zip"
+
+cd ${env:LPSOLVE_WORKSPACE}/extra/O-MATRIX/lpsolve
+echo "Packaging files from ${PWD} into ${zipPath}"
+7z a -tzip -bso0 -bsp0 -r $zipPath `
+    changes `
+    *.oms `
+    README.txt
+
+cd ${env:LPSOLVE_WORKSPACE}/extra/man
+echo "Packaging files from ${PWD} into ${zipPath}"
+7z a -tzip -bso0 -bsp0 $zipPath `
+    O-Matrix.htm

--- a/release_process/build-zip-PHP_exe_winXX.ps1
+++ b/release_process/build-zip-PHP_exe_winXX.ps1
@@ -1,0 +1,17 @@
+. $PSScriptRoot/check_env_vars.ps1
+$requiredEnvVars = @("LPSOLVE_WORKSPACE", "LPSOLVE_VERSION", "LPSOLVE_PLATFORM")
+Assert-EnvironmentVariablesAreNotEmpty $requiredEnvVars
+
+$zipPath = "${env:LPSOLVE_WORKSPACE}/lp_solve_${env:LPSOLVE_VERSION}_PHP_exe_${env:LPSOLVE_PLATFORM}.zip"
+
+cd ${env:LPSOLVE_WORKSPACE}/extra/PHP
+echo "Packaging files from ${PWD} into ${zipPath}"
+7z a -tzip -bso0 -bsp0 -r $zipPath `
+    changes `
+    *.php `
+    README.txt
+
+cd ${env:LPSOLVE_WORKSPACE}/extra/man
+echo "Packaging files from ${PWD} into ${zipPath}"
+7z a -tzip -bso0 -bsp0 $zipPath `
+    PHP.htm

--- a/release_process/build-zip-Sysquake_exe_winXX.ps1
+++ b/release_process/build-zip-Sysquake_exe_winXX.ps1
@@ -1,0 +1,17 @@
+. $PSScriptRoot/check_env_vars.ps1
+$requiredEnvVars = @("LPSOLVE_WORKSPACE", "LPSOLVE_VERSION", "LPSOLVE_PLATFORM")
+Assert-EnvironmentVariablesAreNotEmpty $requiredEnvVars
+
+$zipPath = "${env:LPSOLVE_WORKSPACE}/lp_solve_${env:LPSOLVE_VERSION}_Sysquake_exe_${env:LPSOLVE_PLATFORM}.zip"
+
+cd ${env:LPSOLVE_WORKSPACE}/extra/Sysquake
+echo "Packaging files from ${PWD} into ${zipPath}"
+7z a -tzip -bso0 -bsp0 -r $zipPath `
+    changes `
+    *.lml `
+    README.txt
+
+cd ${env:LPSOLVE_WORKSPACE}/extra/man
+echo "Packaging files from ${PWD} into ${zipPath}"
+7z a -tzip -bso0 -bsp0 $zipPath `
+    Sysquake.htm

--- a/release_process/build-zip-access.ps1
+++ b/release_process/build-zip-access.ps1
@@ -1,0 +1,10 @@
+. $PSScriptRoot/check_env_vars.ps1
+$requiredEnvVars = @("LPSOLVE_WORKSPACE", "LPSOLVE_VERSION")
+Assert-EnvironmentVariablesAreNotEmpty $requiredEnvVars
+
+$zipPath = "${env:LPSOLVE_WORKSPACE}/lp_solve_${env:LPSOLVE_VERSION}_access.zip"
+
+cd ${env:LPSOLVE_WORKSPACE}/extra/Access
+echo "Packaging files from ${PWD} into ${zipPath}"
+7z a -tzip -bso0 -bsp0 $zipPath `
+    demo.mdb

--- a/release_process/build-zip-cs.net.ps1
+++ b/release_process/build-zip-cs.net.ps1
@@ -1,0 +1,11 @@
+. $PSScriptRoot/check_env_vars.ps1
+$requiredEnvVars = @("LPSOLVE_WORKSPACE", "LPSOLVE_VERSION")
+Assert-EnvironmentVariablesAreNotEmpty $requiredEnvVars
+
+$zipPath = "${env:LPSOLVE_WORKSPACE}/lp_solve_${env:LPSOLVE_VERSION}_cs.net.zip"
+
+cd ${env:LPSOLVE_WORKSPACE}/extra/cs.net
+echo "Packaging files from ${PWD} into ${zipPath}"
+7z a -tzip -bso0 -bsp0 $zipPath `
+    * `
+    '-x!app.config'

--- a/release_process/build-zip-dev_winXX.ps1
+++ b/release_process/build-zip-dev_winXX.ps1
@@ -1,0 +1,26 @@
+. $PSScriptRoot/check_env_vars.ps1
+$requiredEnvVars = @("LPSOLVE_WORKSPACE", "LPSOLVE_VERSION", "LPSOLVE_PLATFORM")
+Assert-EnvironmentVariablesAreNotEmpty $requiredEnvVars
+
+echo "Building lpsolve55 library for platform ${env:LPSOLVE_PLATFORM}"
+cd ${env:LPSOLVE_WORKSPACE}/lpsolve55
+./cvc8NOmsvcrt.bat
+
+$zipPath = "${env:LPSOLVE_WORKSPACE}/lp_solve_${env:LPSOLVE_VERSION}_dev_${env:LPSOLVE_PLATFORM}.zip"
+
+cd ${env:LPSOLVE_WORKSPACE}
+echo "Packaging files from ${PWD} into ${zipPath}"
+7z a -tzip -bso0 -bsp0 $zipPath `
+    lp_Hash.h `
+    lp_lib.h `
+    lp_matrix.h `
+    lp_mipbb.h `
+    lp_SOS.h `
+    lp_types.h `
+    lp_utils.h
+
+cd ${env:LPSOLVE_WORKSPACE}/lpsolve55/bin/${env:LPSOLVE_PLATFORM}
+echo "Packaging files from ${PWD} into ${zipPath}"
+7z a -tzip -bso0 -bsp0 $zipPath `
+    * `
+    '-x!lpsolve55.exp'

--- a/release_process/build-zip-excel.ps1
+++ b/release_process/build-zip-excel.ps1
@@ -1,0 +1,10 @@
+. $PSScriptRoot/check_env_vars.ps1
+$requiredEnvVars = @("LPSOLVE_WORKSPACE", "LPSOLVE_VERSION")
+Assert-EnvironmentVariablesAreNotEmpty $requiredEnvVars
+
+$zipPath = "${env:LPSOLVE_WORKSPACE}/lp_solve_${env:LPSOLVE_VERSION}_excel.zip"
+
+cd ${env:LPSOLVE_WORKSPACE}/extra/excel
+echo "Packaging files from ${PWD} into ${zipPath}"
+7z a -tzip -bso0 -bsp0 $zipPath `
+    demo.xls

--- a/release_process/build-zip-exe_winXX.ps1
+++ b/release_process/build-zip-exe_winXX.ps1
@@ -1,0 +1,13 @@
+. $PSScriptRoot/check_env_vars.ps1
+$requiredEnvVars = @("LPSOLVE_WORKSPACE", "LPSOLVE_VERSION", "LPSOLVE_PLATFORM")
+Assert-EnvironmentVariablesAreNotEmpty $requiredEnvVars
+
+echo "Building lp_solve.exe for platform ${env:LPSOLVE_PLATFORM}"
+cd ${env:LPSOLVE_WORKSPACE}/lp_solve
+./cvc8.bat
+
+$zipPath = "${env:LPSOLVE_WORKSPACE}/lp_solve_${env:LPSOLVE_VERSION}_exe_${env:LPSOLVE_PLATFORM}.zip"
+
+cd ${env:LPSOLVE_WORKSPACE}/lp_solve/bin/${env:LPSOLVE_PLATFORM}
+echo "Packaging files from ${PWD} into ${zipPath}"
+7z a -tzip -bso0 -bsp0 $zipPath lp_solve.exe

--- a/release_process/build-zip-java.ps1
+++ b/release_process/build-zip-java.ps1
@@ -1,0 +1,29 @@
+. $PSScriptRoot/check_env_vars.ps1
+$requiredEnvVars = @("LPSOLVE_WORKSPACE", "LPSOLVE_VERSION")
+Assert-EnvironmentVariablesAreNotEmpty $requiredEnvVars
+
+$zipPath = "${env:LPSOLVE_WORKSPACE}/lp_solve_${env:LPSOLVE_VERSION}_java.zip"
+
+cd ${env:LPSOLVE_WORKSPACE}/extra
+
+# TODO, this could probably be done with .gitattributes
+echo "Fixing newlines of Unix scripts"
+$scriptFiles=@("lp_solve_5.5_java/demo/build", "lp_solve_5.5_java/demo/run_demo", "lp_solve_5.5_java/demo/run_unittests", "lp_solve_5.5_java/src/java/lpsolve/build")
+foreach ($f in $scriptFiles) {
+    (Get-Content $f -Raw).Replace("`r`n","`n") | Set-Content $f -NoNewLine -Force
+}
+
+echo "Packaging files from ${PWD} into ${zipPath}"
+7z a -tzip -bso0 -bsp0 -r $zipPath `
+    lp_solve_5.5_java/demo `
+    lp_solve_5.5_java/demo2 `
+    lp_solve_5.5_java/docs `
+    lp_solve_5.5_java/src `
+    lp_solve_5.5_java/CHANGES.txt `
+    lp_solve_5.5_java/LGPL `
+    lp_solve_5.5_java/README.html `
+    '-x!lp_solve_5.5_java/demo/*.class' `
+    '-x!lp_solve_5.5_java/demo/*.log' `
+    '-x!lp_solve_5.5_java/demo/lpsolve' `
+    '-x!lp_solve_5.5_java/src/java/*.class' `
+    '-x!model.lp'

--- a/release_process/build-zip-octave_exe_winXX.ps1
+++ b/release_process/build-zip-octave_exe_winXX.ps1
@@ -1,0 +1,12 @@
+. $PSScriptRoot/check_env_vars.ps1
+$requiredEnvVars = @("LPSOLVE_WORKSPACE", "LPSOLVE_VERSION", "LPSOLVE_PLATFORM")
+Assert-EnvironmentVariablesAreNotEmpty $requiredEnvVars
+
+$zipPath = "${env:LPSOLVE_WORKSPACE}/lp_solve_${env:LPSOLVE_VERSION}_octave_exe_${env:LPSOLVE_PLATFORM}.zip"
+
+cd ${env:LPSOLVE_WORKSPACE}/extra/octave/lpsolve
+echo "Packaging files from ${PWD} into ${zipPath}"
+7z a -tzip -bso0 -bsp0 -r $zipPath `
+    changes `
+    *.m `
+    README.txt

--- a/release_process/build-zip-scilab_exe_winXX.ps1
+++ b/release_process/build-zip-scilab_exe_winXX.ps1
@@ -1,0 +1,16 @@
+. $PSScriptRoot/check_env_vars.ps1
+$requiredEnvVars = @("LPSOLVE_WORKSPACE", "LPSOLVE_VERSION", "LPSOLVE_PLATFORM")
+Assert-EnvironmentVariablesAreNotEmpty $requiredEnvVars
+
+$zipPath = "${env:LPSOLVE_WORKSPACE}/lp_solve_${env:LPSOLVE_VERSION}_scilab_exe_${env:LPSOLVE_PLATFORM}.zip"
+
+cd ${env:LPSOLVE_WORKSPACE}/extra/scilab/lpsolve
+echo "Packaging files from ${PWD} into ${zipPath}"
+7z a -tzip -bso0 -bsp0 -r $zipPath `
+    * `
+    '-x!src/'
+
+cd ${env:LPSOLVE_WORKSPACE}/extra/man
+echo "Packaging files from ${PWD} into ${zipPath}"
+7z a -tzip -bso0 -bsp0 $zipPath `
+    Scilab.htm

--- a/release_process/build-zip-vb.net.ps1
+++ b/release_process/build-zip-vb.net.ps1
@@ -1,0 +1,11 @@
+. $PSScriptRoot/check_env_vars.ps1
+$requiredEnvVars = @("LPSOLVE_WORKSPACE", "LPSOLVE_VERSION")
+Assert-EnvironmentVariablesAreNotEmpty $requiredEnvVars
+
+$zipPath = "${env:LPSOLVE_WORKSPACE}/lp_solve_${env:LPSOLVE_VERSION}_vb.net.zip"
+
+cd ${env:LPSOLVE_WORKSPACE}/extra/VB.NET
+echo "Packaging files from ${PWD} into ${zipPath}"
+7z a -tzip -bso0 -bsp0 $zipPath `
+    * `
+    '-x!app.config'

--- a/release_process/build-zip-vb.ps1
+++ b/release_process/build-zip-vb.ps1
@@ -1,0 +1,12 @@
+. $PSScriptRoot/check_env_vars.ps1
+$requiredEnvVars = @("LPSOLVE_WORKSPACE", "LPSOLVE_VERSION")
+Assert-EnvironmentVariablesAreNotEmpty $requiredEnvVars
+
+$zipPath = "${env:LPSOLVE_WORKSPACE}/lp_solve_${env:LPSOLVE_VERSION}_vb.zip"
+
+cd ${env:LPSOLVE_WORKSPACE}/extra/vb
+echo "Packaging files from ${PWD} into ${zipPath}"
+7z a -tzip -bso0 -bsp0 $zipPath `
+    Module1.bas `
+    lpsolve55.cls `
+    demo.vbp

--- a/release_process/check_env_vars.ps1
+++ b/release_process/check_env_vars.ps1
@@ -1,0 +1,21 @@
+function Assert-EnvironmentVariablesAreNotEmpty {
+    param (
+        [string[]]$VariableNames
+    )
+
+    $results = @()
+
+    foreach ($varName in $VariableNames) {
+        $envVar = Get-ChildItem Env:$varName -ErrorAction SilentlyContinue
+
+        if ($envVar -and ($envVar.Value -ne "") ) {
+            # Variable exists
+        } else {
+            $results += $varName
+        }
+    }
+
+    if ($results.Count -gt 0) {
+        throw "The following expected environment variables are missing: $results"
+    }
+}

--- a/release_process/check_env_vars.sh
+++ b/release_process/check_env_vars.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+function assertEnvironmentVariablesAreNotEmpty() {
+    local variableNames=("$@")
+    local missingVariables=()
+    for variableName in "${variableNames[@]}"; do
+        if [ "${!variableName}" == "" ]; then
+            missingVariables+=($variableName)
+        fi
+    done
+
+    if [ ${#missingVariables[@]}  -gt 0 ]; then
+        >&2 echo "The following expected environment variables are missing: ${missingVariables[@]}"
+        exit 1
+    fi
+}


### PR DESCRIPTION
# Description
This pull request contains a workflow for GitHub Actions to prepare release files automatically for the next release. It does not push the files in a release itself, it just prepares them. 

## End Goal
This Pull Request is the first of a few. My end goal is that next release does not have only win32 and win64 zip/tar.gz files but also the ux64 and ux32 ones.

## This Pull Request vs Past Releases

This pull request builds the same files as were in [Release 5.5.2.14](https://github.com/lp-solve/lp_solve/releases/tag/5.5.2.14) with the small differences listed below. Please note that zip/gz files in release 5.5.2.14 seem to be missing files compared to 5.5.2.11 version. In the release-files.yaml file, there are TODOs scattered around listing those differences and I list them here as well **for future reference**. 

### Differences with 5.5.2.14 release

- Major:
    - lp_solve_5.5.2.XX_IDE_Setup.exe is not generated at all. I did not find a way to build Delphi code using GitHub provided runners. That would need to be generated manually at each release and uploaded along the automatically generated files.
- Minor:
    - End-of-line changes in various files, sometimes from LF to CRLF sometimes the other way around. Most of those changes made all files in the same zip/.gz file use the same line-endings.
    - Empty folders and 2 hidden files (.gitignore, .DS_Store) removed in lp_solve_5.5.2.XX_doc.tar.gz
- Improvements:
    - Added missing files in lp_solve_5.5.2.XX_xli_DIMACS_source.tar.gz. The DIMACS*.htm files were referencing .gif files that were not in the original .tar.gz, I added them.
    - Some files were added in repository since last release and are now bundled in the different ...source.tar.gz (*.bat, *.vcxproj, *2010.sln, gen, gen.osx, ccc, ccc.osx, IsolatedTest.java, Perf.java, many *.py)

### Differences between actual files of releases 5.5.2.14 and 5.5.2.11

- Files missing *within* release files

| Archive file | Files missing | Notes |
| -- | -- | -- |
| lp_solve_5.5.2.XX_AMPL_exe_win32.zip | lpsolve.exe | |
| lp_solve_5.5.2.XX_COM.zip | lpsolve55COM.dll | |
| lp_solve_5.5.2.XX_Euler_exe_win32.zip | eulpsolve.dll<br/>intsimplex.e<br/>loadlpsolve.en<br/>loadlpsolve70.en<br/>Test Problems.en | |
| lp_solve_5.5.2.XX_exe_win32.zip | bfp_etaPFI.dll<br/>bfp_GLPK.dll<br/>bfp_LUSOL.dll<br/>contents.txt<br/>xli_CPLEX.dll<br/>xli_DIMACS.dll<br/>xli_LINDO.dll<br/>xli_LPFML.dll<br/>xli_MathProg.dll<br/>xli_MPS.dll<br/>xli_XPRESS.dll<br/>xli_ZIMPL.dll | |
| lp_solve_5.5.2.XX_exe_win64.zip | bfp_etaPFI.dll<br/>bfp_GLPK.dll<br/>bfp_LUSOL.dll<br/>contents.txt<br/>xli_CPLEX.dll<br/>xli_DIMACS.dll<br/>xli_LINDO.dll<br/>xli_MathProg.dll<br/>xli_MPS.dll<br/>xli_XPRESS.dll<br/> | Has 2 files less than win32 |
| lp_solve_5.5.2.XX_FreeMat_exe_win32.zip | fmlpsolve.dll | |
| lp_solve_5.5.2.XX_java.zip | lib/mac/build-osx<br/>lib/ux32/liblpsolve55j.so<br/>lib/ux64/liblpsolve55j.so<br/>lib/win32/lpsolve55j.dll<br/>lib/win64/lpsolve55j.dll<br/>lib/build<br/>lib/build.bat<br/>lib/junit.jar<br/>lib/lpsolve55j.jar | |
| lp_solve_5.5.2.XX_MATLAB_exe_win32.zip | bin/win32/lp_explicit.lib<br/>bin/win32/mxlpsolve.dll<br/>bin/win32/mxlpsolve.mexw32 | |
| lp_solve_5.5.2.XX_MATLAB_exe_win64.zip | bin/win64/lp_explicit.lib<br/>bin/win64/mxlpsolve.mexw64 | Has one file less than win32 version |
| lp_solve_5.5.2.XX_MATLAB_source.tar.gz | extra/MATLAB/lpsolve/bin/win{32,64}/lp_explicit.lib | |
| lp_solve_5.5.2.XX_octave_exe_win32.zip | octlpsolve.oct | |
| lp_solve_5.5.2.XX_OMATRIX_exe_win32.zip | omlpsolve.dll | |
| lp_solve_5.5.2.XX_PHP_exe_win32.zip | php4/php_phplpsolve55.dll<br/>php5_2/php_phplpsolve55.dll<br/>php5_3/php_phplpsolve55.dll | |
| lp_solve_5.5.2.XX_scilab_exe_win32.zip | bin/win32/sclpsolve.dll<br/>lib (a binary file) | |
| lp_solve_5.5.2.XX_scilab_exe_win64.zip | bin/win64/sclpsolve.dll<br/>lib (a binary file) | |
| lp_solve_5.5.2.XX_Sysquake_exe_win32.zip | sqlpsolveext.dll | |


- Release Files not present at all in 5.5.2.14
    - lp_solve_5.5.2.XX_AMPL_exe_osx32.tar.gz
    - lp_solve_5.5.2.XX_AMPL_exe_ux32.tar.gz
    - lp_solve_5.5.2.XX_dev_osx32.tar.gz
    - lp_solve_5.5.2.XX_dev_ux32.tar.gz
    - lp_solve_5.5.2.XX_dev_ux64.tar.gz
    - lp_solve_5.5.2.XX_exe_osx32.tar.gz
    - lp_solve_5.5.2.XX_exe_ux32.tar.gz
    - lp_solve_5.5.2.XX_exe_ux64.tar.gz
    - lp_solve_5.5.2.XX_FreeMat_exe_osx32.tar.gz
    - lp_solve_5.5.2.XX_FreeMat_exe_ux32.tar.gz
    - lp_solve_5.5.2.XX_FreeMat_exe_ux64.tar.gz
    - lp_solve_5.5.2.XX_MATLAB_exe_osx32.tar.gz
    - lp_solve_5.5.2.XX_MATLAB_exe_ux32.tar.gz
    - lp_solve_5.5.2.XX_MATLAB_exe_ux64.tar.gz
    - lp_solve_5.5.2.XX_MSF_demo.zip
    - lp_solve_5.5.2.XX_octave_exe_osx32.tar.gz
    - lp_solve_5.5.2.XX_octave_exe_ux32.tar.gz
    - lp_solve_5.5.2.XX_octave_exe_ux64.tar.gz
    - lp_solve_5.5.2.XX_PHP_exe_ux32.tar.gz
    - lp_solve_5.5.2.XX_PHP_exe_ux64.tar.gz
    - lp_solve_5.5.2.XX_Python2.3_exe_osx32.tar.gz
    - lp_solve_5.5.2.XX_Python2.4_exe_win32.zip
    - lp_solve_5.5.2.XX_Python2.5_exe_ux32.tar.gz
    - lp_solve_5.5.2.XX_Python2.5_exe_ux64.tar.gz
    - lp_solve_5.5.2.XX_Python2.5_exe_win32.zip
    - lp_solve_5.5.2.XX_Python2.6_exe_win32.zip
    - lp_solve_5.5.2.XX_Python2.6_exe_win64.zip
    - lp_solve_5.5.2.XX_scilab_exe_osx32.tar.gz
    - lp_solve_5.5.2.XX_scilab_exe_ux32.tar.gz
    - lp_solve_5.5.2.XX_scilab_exe_ux64.tar.gz
    - lp_solve_5.5.2.XX_Sysquake_exe_osx32.tar.gz
    - lp_solve_5.5.2.XX_Sysquake_exe_ux32.tar.gz