### PR TITLE
Use GitHub actions to prepare some Unix release files

### DIFF
--- a/.github/workflows/release-files.yaml
+++ b/.github/workflows/release-files.yaml
@@ -208,6 +208,65 @@ jobs:
         path: |
           *.zip
 
+  build-linux:
+    needs: determine-version
+    strategy:
+      matrix:
+        platform: ["ux32", "ux64"]
+    runs-on: ubuntu-latest
+    env:
+      LPSOLVE_WORKSPACE: ${{ github.workspace }}
+      LPSOLVE_VERSION: ${{ needs.determine-version.outputs.LPSOLVE_VERSION }}
+      LPSOLVE_PLATFORM: ${{ matrix.platform }}
+
+    steps:
+
+    - name: Install 32-bit toolchain
+      if: matrix.platform == 'ux32'
+      run: |
+        LPSOLVE_OS_CODENAME=$(cat /etc/os-release|grep VERSION_CODENAME|sed -E 's/VERSION_CODENAME=//')
+        if [ "$LPSOLVE_OS_CODENAME" = "buster" ] || [ "$LPSOLVE_OS_CODENAME" = "bullseye" ] ; then
+          echo "Detected debian $LPSOLVE_OS_CODENAME - changing apt sources to archive.debian.org"
+          # old debian release, sources have been moved to archive.debian.org
+          sed -i s/deb.debian.org/archive.debian.org/g /etc/apt/sources.list
+        fi
+
+        apt-get update
+        apt-get install -y gcc-i686-linux-gnu binutils-i686-linux-gnu
+
+        # ensure to use the 32 bit compiler in subsequent steps
+        echo 'CC=i686-linux-gnu-gcc -m32' >> "$GITHUB_ENV"
+
+    - name: Checkout
+      uses: actions/checkout@v5
+
+    - name: Install missing dependencies
+      run: |
+        set -v # echo commands
+        
+        # set glpkdir to where glpk is located, used in bfp/bfp_GLPK/ccc
+        # also set it for future steps
+        glpkdir=${LPSOLVE_WORKSPACE}/dependencies/glpk
+        echo "glpkdir=${glpkdir}" >> "$GITHUB_ENV"
+
+        mkdir -p $glpkdir
+        curl -s -L https://slackware.cs.utah.edu/pub/gnu/glpk/glpk-4.13.tar.gz | tar -xvz -C $glpkdir --strip-components=1
+
+    - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_dev_${{ env.LPSOLVE_PLATFORM }}.tar.gz
+      run: ./release_process/build-targz-dev_uxXX.sh
+      
+    - name: Build lp_solve_${{ env.LPSOLVE_VERSION }}_exe_${{ env.LPSOLVE_PLATFORM }}.tar.gz
+      run: ./release_process/build-targz-exe_uxXX.sh
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ env.LPSOLVE_PLATFORM }}
+        compression-level: 0 # no compression - already compressed
+        retention-days: 1
+        path: |
+          *.tar.gz
+
   zip-on-windows:
     needs: determine-version
     runs-on: windows-latest
@@ -364,6 +423,7 @@ jobs:
     needs:
       - build-win64
       - build-win32
+      - build-linux
       - zip-on-windows
       - tar-gz-on-linux
     steps:

--- a/.github/workflows/release-files.yaml
+++ b/.github/workflows/release-files.yaml
@@ -219,6 +219,33 @@ jobs:
       LPSOLVE_VERSION: ${{ needs.determine-version.outputs.LPSOLVE_VERSION }}
       LPSOLVE_PLATFORM: ${{ matrix.platform }}
 
+    ##### Start section - older glibc support #####
+    # To build binaries with dependencies on older libc versions,
+    # we use a gcc on an earlier distro through a container.
+    # If we want to drop that support, we can remove the defaults.run.shell and container elements below.
+    defaults:
+      run:
+        shell: bash # overriden because default in container jobs is sh
+    container:
+      image: gcc:10.4-buster        # uses symbols from glibc 2.2.5-2.14 in built liblpsolve55.so and others
+      # image: gcc:12.3-bullseye    # uses symbols from glibc 2.2.5-2.29 in built liblpsolve55.so
+      # image: gcc:15.2-bookworm    # uses symbols from glibc ... not tested yet
+      # no container, ubuntu-22.04  # uses symbols from glibc 2.2.5-2.34 in built liblpsolve55.so
+      # no container, ubuntu-24.04  # uses symbols from glibc 2.2.5-2.38 in built liblpsolve55.so
+      # to check versions of glibc used by built liblpsolve55.so:
+      #   readelf --dyn-syms -W /path/to/liblpsolve55.so | grep @GLIBC_ | sed -E 's/^.*@GLIBC_([^ ]+) .*$/\1/' | sort | uniq
+      env:
+        # different path in container, mapped to host workspace in volume and options below
+        LPSOLVE_WORKSPACE: /githubworkspace
+        LPSOLVE_VERSION: ${{ env.LPSOLVE_VERSION }}
+        LPSOLVE_PLATFORM: ${{ env.LPSOLVE_PLATFORM }}
+      volumes:
+        # ${{ env. }} is not available in this section, using ${{ github.workspace }} instead
+        - ${{ github.workspace }}:/githubworkspace
+      # set working directory to workspace
+      options: -w /githubworkspace
+    ##### End section - older glibc support #####
+
     steps:
 
     - name: Install 32-bit toolchain

--- a/.gitignore
+++ b/.gitignore
@@ -372,3 +372,4 @@ distrib/
 
 # build artifacts
 lpsolve55/RCa*
+output/

--- a/bfp/bfp_GLPK/ccc
+++ b/bfp/bfp_GLPK/ccc
@@ -2,8 +2,8 @@
 
 # Tested with glpk 4.2 and 4.7 and 4.13
 
-# Location where glpk is located.
-glpkdir=/glpk/glpk-4.13
+# Location where glpk is located, defaults to /glpk/glpk-4.13 if not set
+glpkdir=${glpkdir:-/glpk/glpk-4.13}
 
 if [ -f ${glpkdir}/src/glprng.c ]
 then glpk1=${glpkdir}/src/glprng.c
@@ -31,16 +31,22 @@ fi
 
 c=${CC:-cc}
 
-MYTMP=`mktemp -d "${TMPDIR:-/tmp}"/lp_solve_XXXXXX`
+# Determine platform if not set.
+# CI will set LPSOLVE_PLATFORM when doing cross-compilation because it cannot run '$MYTMP/platform' executable.
+if [ "$LPSOLVE_PLATFORM" = "" ]; then
+     MYTMP=`mktemp -d "${TMPDIR:-/tmp}"/lp_solve_XXXXXX`
 
-#determine platform (32/64 bit)
->"$MYTMP"/platform.c
-echo '#include <stdlib.h>'>>"$MYTMP"/platform.c
-echo '#include <stdio.h>'>>"$MYTMP"/platform.c
-echo 'int main(){printf("ux%d", (int) (sizeof(void *)*8)); return 0;}'>>"$MYTMP"/platform.c
-$c "$MYTMP"/platform.c -o "$MYTMP"/platform
-PLATFORM=`"$MYTMP"/platform`
-rm "$MYTMP"/platform "$MYTMP"/platform.c >/dev/null 2>&1
+     #determine platform (32/64 bit)
+     >"$MYTMP"/platform.c
+     echo '#include <stdlib.h>'>>"$MYTMP"/platform.c
+     echo '#include <stdio.h>'>>"$MYTMP"/platform.c
+     echo 'int main(){printf("ux%d", (int) (sizeof(void *)*8)); return 0;}'>>"$MYTMP"/platform.c
+     $c "$MYTMP"/platform.c -o "$MYTMP"/platform
+     PLATFORM=`"$MYTMP"/platform`
+     rm "$MYTMP"/platform "$MYTMP"/platform.c >/dev/null 2>&1
+else
+     PLATFORM=$LPSOLVE_PLATFORM
+fi
 
 mkdir bin bin/$PLATFORM >/dev/null 2>&1
 

--- a/bfp/bfp_LUSOL/ccc
+++ b/bfp/bfp_LUSOL/ccc
@@ -3,16 +3,22 @@ src='../../shared/commonlib.c ../../colamd/colamd.c lp_LUSOL.c ../../lp_utils.c 
 
 c=${CC:-cc}
 
-MYTMP=`mktemp -d "${TMPDIR:-/tmp}"/lp_solve_XXXXXX`
+# Determine platform if not set.
+# CI will set LPSOLVE_PLATFORM when doing cross-compilation because it cannot run '$MYTMP/platform' executable.
+if [ "$LPSOLVE_PLATFORM" = "" ]; then
+     MYTMP=`mktemp -d "${TMPDIR:-/tmp}"/lp_solve_XXXXXX`
 
-#determine platform (32/64 bit)
->"$MYTMP"/platform.c
-echo '#include <stdlib.h>'>>"$MYTMP"/platform.c
-echo '#include <stdio.h>'>>"$MYTMP"/platform.c
-echo 'int main(){printf("ux%d", (int) (sizeof(void *)*8)); return 0;}'>>"$MYTMP"/platform.c
-$c "$MYTMP"/platform.c -o "$MYTMP"/platform
-PLATFORM=`"$MYTMP"/platform`
-rm "$MYTMP"/platform "$MYTMP"/platform.c >/dev/null 2>&1
+     #determine platform (32/64 bit)
+     >"$MYTMP"/platform.c
+     echo '#include <stdlib.h>'>>"$MYTMP"/platform.c
+     echo '#include <stdio.h>'>>"$MYTMP"/platform.c
+     echo 'int main(){printf("ux%d", (int) (sizeof(void *)*8)); return 0;}'>>"$MYTMP"/platform.c
+     $c "$MYTMP"/platform.c -o "$MYTMP"/platform
+     PLATFORM=`"$MYTMP"/platform`
+     rm "$MYTMP"/platform "$MYTMP"/platform.c >/dev/null 2>&1
+else
+     PLATFORM=$LPSOLVE_PLATFORM
+fi
 
 mkdir bin bin/$PLATFORM >/dev/null 2>&1
 

--- a/bfp/bfp_etaPFI/ccc
+++ b/bfp/bfp_etaPFI/ccc
@@ -3,16 +3,22 @@ src='../../shared/commonlib.c ../../colamd/colamd.c lp_etaPFI.c ../../lp_utils.c
 
 c=${CC:-cc}
 
-MYTMP=`mktemp -d "${TMPDIR:-/tmp}"/lp_solve_XXXXXX`
+# Determine platform if not set.
+# CI will set LPSOLVE_PLATFORM when doing cross-compilation because it cannot run '$MYTMP/platform' executable.
+if [ "$LPSOLVE_PLATFORM" = "" ]; then
+     MYTMP=`mktemp -d "${TMPDIR:-/tmp}"/lp_solve_XXXXXX`
 
-#determine platform (32/64 bit)
->"$MYTMP"/platform.c
-echo '#include <stdlib.h>'>>"$MYTMP"/platform.c
-echo '#include <stdio.h>'>>"$MYTMP"/platform.c
-echo 'int main(){printf("ux%d", (int) (sizeof(void *)*8)); return 0;}'>>"$MYTMP"/platform.c
-$c "$MYTMP"/platform.c -o "$MYTMP"/platform
-PLATFORM=`"$MYTMP"/platform`
-rm "$MYTMP"/platform "$MYTMP"/platform.c >/dev/null 2>&1
+     #determine platform (32/64 bit)
+     >"$MYTMP"/platform.c
+     echo '#include <stdlib.h>'>>"$MYTMP"/platform.c
+     echo '#include <stdio.h>'>>"$MYTMP"/platform.c
+     echo 'int main(){printf("ux%d", (int) (sizeof(void *)*8)); return 0;}'>>"$MYTMP"/platform.c
+     $c "$MYTMP"/platform.c -o "$MYTMP"/platform
+     PLATFORM=`"$MYTMP"/platform`
+     rm "$MYTMP"/platform "$MYTMP"/platform.c >/dev/null 2>&1
+else
+     PLATFORM=$LPSOLVE_PLATFORM
+fi
 
 mkdir bin bin/$PLATFORM >/dev/null 2>&1
 

--- a/lp_solve/ccc
+++ b/lp_solve/ccc
@@ -2,16 +2,22 @@
 src='../lp_MDO.c ../shared/commonlib.c ../colamd/colamd.c ../shared/mmio.c ../shared/myblas.c ../ini.c ../fortify.c ../lp_rlp.c ../lp_crash.c ../bfp/bfp_LUSOL/lp_LUSOL.c ../bfp/bfp_LUSOL/LUSOL/lusol.c ../lp_Hash.c ../lp_lib.c ../lp_wlp.c ../lp_matrix.c ../lp_mipbb.c ../lp_MPS.c ../lp_params.c ../lp_presolve.c ../lp_price.c ../lp_pricePSE.c ../lp_report.c ../lp_scale.c ../lp_simplex.c lp_solve.c ../lp_SOS.c ../lp_utils.c ../yacc_read.c'
 c=${CC:-cc}
 
-MYTMP=`mktemp -d "${TMPDIR:-/tmp}"/lp_solve_XXXXXX`
+# Determine platform if not set.
+# CI will set LPSOLVE_PLATFORM when doing cross-compilation because it cannot run '$MYTMP/platform' executable.
+if [ "$LPSOLVE_PLATFORM" = "" ]; then
+     MYTMP=`mktemp -d "${TMPDIR:-/tmp}"/lp_solve_XXXXXX`
 
-#determine platform (32/64 bit)
->"$MYTMP"/platform.c
-echo '#include <stdlib.h>'>>"$MYTMP"/platform.c
-echo '#include <stdio.h>'>>"$MYTMP"/platform.c
-echo 'int main(){printf("ux%d", (int) (sizeof(void *)*8)); return 0;}'>>"$MYTMP"/platform.c
-$c "$MYTMP"/platform.c -o "$MYTMP"/platform
-PLATFORM=`"$MYTMP"/platform`
-rm "$MYTMP"/platform "$MYTMP"/platform.c >/dev/null 2>&1
+     #determine platform (32/64 bit)
+     >"$MYTMP"/platform.c
+     echo '#include <stdlib.h>'>>"$MYTMP"/platform.c
+     echo '#include <stdio.h>'>>"$MYTMP"/platform.c
+     echo 'int main(){printf("ux%d", (int) (sizeof(void *)*8)); return 0;}'>>"$MYTMP"/platform.c
+     $c "$MYTMP"/platform.c -o "$MYTMP"/platform
+     PLATFORM=`"$MYTMP"/platform`
+     rm "$MYTMP"/platform "$MYTMP"/platform.c >/dev/null 2>&1
+else
+     PLATFORM=$LPSOLVE_PLATFORM
+fi
 
 mkdir bin bin/$PLATFORM >/dev/null 2>&1
 

--- a/lpsolve55/ccc
+++ b/lpsolve55/ccc
@@ -2,16 +2,22 @@
 src='../lp_MDO.c ../shared/commonlib.c ../shared/mmio.c ../shared/myblas.c ../ini.c ../fortify.c ../colamd/colamd.c ../lp_rlp.c ../lp_crash.c ../bfp/bfp_LUSOL/lp_LUSOL.c ../bfp/bfp_LUSOL/LUSOL/lusol.c ../lp_Hash.c ../lp_lib.c ../lp_wlp.c ../lp_matrix.c ../lp_mipbb.c ../lp_MPS.c ../lp_params.c ../lp_presolve.c ../lp_price.c ../lp_pricePSE.c ../lp_report.c ../lp_scale.c ../lp_simplex.c ../lp_SOS.c ../lp_utils.c ../yacc_read.c'
 c=${CC:-cc}
 
-MYTMP=`mktemp -d "${TMPDIR:-/tmp}"/lp_solve_XXXXXX`
+# Determine platform if not set.
+# CI will set LPSOLVE_PLATFORM when doing cross-compilation because it cannot run '$MYTMP/platform' executable.
+if [ "$LPSOLVE_PLATFORM" = "" ]; then
+     MYTMP=`mktemp -d "${TMPDIR:-/tmp}"/lp_solve_XXXXXX`
 
-#determine platform (32/64 bit)
->"$MYTMP"/platform.c
-echo '#include <stdlib.h>'>>"$MYTMP"/platform.c
-echo '#include <stdio.h>'>>"$MYTMP"/platform.c
-echo 'int main(){printf("ux%d", (int) (sizeof(void *)*8)); return 0;}'>>"$MYTMP"/platform.c
-$c "$MYTMP"/platform.c -o "$MYTMP"/platform
-PLATFORM=`"$MYTMP"/platform`
-rm "$MYTMP"/platform "$MYTMP"/platform.c >/dev/null 2>&1
+     #determine platform (32/64 bit)
+     >"$MYTMP"/platform.c
+     echo '#include <stdlib.h>'>>"$MYTMP"/platform.c
+     echo '#include <stdio.h>'>>"$MYTMP"/platform.c
+     echo 'int main(){printf("ux%d", (int) (sizeof(void *)*8)); return 0;}'>>"$MYTMP"/platform.c
+     $c "$MYTMP"/platform.c -o "$MYTMP"/platform
+     PLATFORM=`"$MYTMP"/platform`
+     rm "$MYTMP"/platform "$MYTMP"/platform.c >/dev/null 2>&1
+else
+     PLATFORM=$LPSOLVE_PLATFORM
+fi
 
 mkdir bin bin/$PLATFORM >/dev/null 2>&1
 

--- a/release_process/build-targz-dev_uxXX.sh
+++ b/release_process/build-targz-dev_uxXX.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+. $(dirname "$0")/check_env_vars.sh
+requiredEnvVars=("LPSOLVE_WORKSPACE" "LPSOLVE_VERSION" "LPSOLVE_PLATFORM")
+assertEnvironmentVariablesAreNotEmpty "${requiredEnvVars[@]}"
+
+TAR_CONTENT_FOLDER=output/dev_${LPSOLVE_PLATFORM}
+mkdir -p $TAR_CONTENT_FOLDER
+TAR_CONTENT_FOLDER=$( realpath $TAR_CONTENT_FOLDER )
+
+echo "Building lpsolve55 library for platform ${LPSOLVE_PLATFORM}"
+cd lpsolve55
+sh ccc
+cp ${LPSOLVE_WORKSPACE}/lpsolve55/bin/${LPSOLVE_PLATFORM}/* $TAR_CONTENT_FOLDER
+
+echo "Packaging lpsolve55 library for platform ${LPSOLVE_PLATFORM}"
+cd ${LPSOLVE_WORKSPACE}
+cp lp_Hash.h lp_lib.h lp_matrix.h lp_mipbb.h lp_SOS.h lp_types.h lp_utils.h $TAR_CONTENT_FOLDER
+cd $TAR_CONTENT_FOLDER
+tar -czf ${LPSOLVE_WORKSPACE}/lp_solve_${LPSOLVE_VERSION}_dev_${LPSOLVE_PLATFORM}.tar.gz *

--- a/release_process/build-targz-exe_uxXX.sh
+++ b/release_process/build-targz-exe_uxXX.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+
+. $(dirname "$0")/check_env_vars.sh
+requiredEnvVars=("LPSOLVE_WORKSPACE" "LPSOLVE_VERSION" "LPSOLVE_PLATFORM")
+assertEnvironmentVariablesAreNotEmpty "${requiredEnvVars[@]}"
+
+TAR_CONTENT_FOLDER=output/exe_${LPSOLVE_PLATFORM}
+mkdir -p $TAR_CONTENT_FOLDER
+TAR_CONTENT_FOLDER=$( realpath $TAR_CONTENT_FOLDER )
+
+for folder in bfp/bfp_GLPK bfp/bfp_etaPFI bfp/bfp_LUSOL xli/xli_CPLEX xli/xli_LINDO xli/xli_MPS xli/xli_XPRESS lp_solve
+do
+    echo "Building $folder for platform ${LPSOLVE_PLATFORM}"
+    cd ${LPSOLVE_WORKSPACE}/$folder
+    sh ccc
+    if [ "$folder" = "lp_solve" ]; then
+        cp ${LPSOLVE_WORKSPACE}/$folder/bin/${LPSOLVE_PLATFORM}/lp_solve $TAR_CONTENT_FOLDER
+    else
+        cp ${LPSOLVE_WORKSPACE}/$folder/bin/${LPSOLVE_PLATFORM}/*.so $TAR_CONTENT_FOLDER
+    fi
+done
+
+cp ${LPSOLVE_WORKSPACE}/release_process/contents_exe_${LPSOLVE_PLATFORM}.txt $TAR_CONTENT_FOLDER/contents.txt
+
+cd $TAR_CONTENT_FOLDER
+tar -czf ${LPSOLVE_WORKSPACE}/lp_solve_${LPSOLVE_VERSION}_exe_${LPSOLVE_PLATFORM}.tar.gz *

--- a/release_process/contents_exe_ux32.txt
+++ b/release_process/contents_exe_ux32.txt
@@ -1,0 +1,10 @@
+lp_solve:           The stand-alone lp_solve program
+
+libbfp_etaPFI.so:   etaPFI bfp library
+libbfp_GLPK.so:     GLPK bfp library
+libbfp_LUSOL.so:    LUSOL bfp library
+
+libxli_CPLEX.so:    Library to read/write CPLEX lp model files.
+libxli_LINDO.so:    Library to read/write LINDO lp model files.
+libxli_MPS.so:      Library to read/write MPS models.
+libxli_XPRESS.so:   Library to read/write Xpress lp model files.

--- a/release_process/contents_exe_ux64.txt
+++ b/release_process/contents_exe_ux64.txt
@@ -1,0 +1,10 @@
+lp_solve:           The stand-alone lp_solve program
+
+libbfp_etaPFI.so:   etaPFI bfp library
+libbfp_GLPK.so:     GLPK bfp library
+libbfp_LUSOL.so:    LUSOL bfp library
+
+libxli_CPLEX.so:    Library to read/write CPLEX lp model files.
+libxli_LINDO.so:    Library to read/write LINDO lp model files.
+libxli_MPS.so:      Library to read/write MPS models.
+libxli_XPRESS.so:   Library to read/write Xpress lp model files.

--- a/xli/xli_CPLEX/ccc
+++ b/xli/xli_CPLEX/ccc
@@ -20,16 +20,22 @@ fi
 
 c=${CC:-cc}
 
-MYTMP=`mktemp -d "${TMPDIR:-/tmp}"/lp_solve_XXXXXX`
+# Determine platform if not set.
+# CI will set LPSOLVE_PLATFORM when doing cross-compilation because it cannot run '$MYTMP/platform' executable.
+if [ "$LPSOLVE_PLATFORM" = "" ]; then
+     MYTMP=`mktemp -d "${TMPDIR:-/tmp}"/lp_solve_XXXXXX`
 
-#determine platform (32/64 bit)
->"$MYTMP"/platform.c
-echo '#include <stdlib.h>'>>"$MYTMP"/platform.c
-echo '#include <stdio.h>'>>"$MYTMP"/platform.c
-echo 'int main(){printf("ux%d", (int) (sizeof(void *)*8)); return 0;}'>>"$MYTMP"/platform.c
-$c "$MYTMP"/platform.c -o "$MYTMP"/platform
-PLATFORM=`"$MYTMP"/platform`
-rm "$MYTMP"/platform "$MYTMP"/platform.c >/dev/null 2>&1
+     #determine platform (32/64 bit)
+     >"$MYTMP"/platform.c
+     echo '#include <stdlib.h>'>>"$MYTMP"/platform.c
+     echo '#include <stdio.h>'>>"$MYTMP"/platform.c
+     echo 'int main(){printf("ux%d", (int) (sizeof(void *)*8)); return 0;}'>>"$MYTMP"/platform.c
+     $c "$MYTMP"/platform.c -o "$MYTMP"/platform
+     PLATFORM=`"$MYTMP"/platform`
+     rm "$MYTMP"/platform "$MYTMP"/platform.c >/dev/null 2>&1
+else
+     PLATFORM=$LPSOLVE_PLATFORM
+fi
 
 mkdir bin bin/$PLATFORM >/dev/null 2>&1
 

--- a/xli/xli_LINDO/ccc
+++ b/xli/xli_LINDO/ccc
@@ -20,16 +20,22 @@ fi
 
 c=${CC:-cc}
 
-MYTMP=`mktemp -d "${TMPDIR:-/tmp}"/lp_solve_XXXXXX`
+# Determine platform if not set.
+# CI will set LPSOLVE_PLATFORM when doing cross-compilation because it cannot run '$MYTMP/platform' executable.
+if [ "$LPSOLVE_PLATFORM" = "" ]; then
+     MYTMP=`mktemp -d "${TMPDIR:-/tmp}"/lp_solve_XXXXXX`
 
-#determine platform (32/64 bit)
->"$MYTMP"/platform.c
-echo '#include <stdlib.h>'>>"$MYTMP"/platform.c
-echo '#include <stdio.h>'>>"$MYTMP"/platform.c
-echo 'int main(){printf("ux%d", (int) (sizeof(void *)*8)); return 0;}'>>"$MYTMP"/platform.c
-$c "$MYTMP"/platform.c -o "$MYTMP"/platform
-PLATFORM=`"$MYTMP"/platform`
-rm "$MYTMP"/platform "$MYTMP"/platform.c >/dev/null 2>&1
+     #determine platform (32/64 bit)
+     >"$MYTMP"/platform.c
+     echo '#include <stdlib.h>'>>"$MYTMP"/platform.c
+     echo '#include <stdio.h>'>>"$MYTMP"/platform.c
+     echo 'int main(){printf("ux%d", (int) (sizeof(void *)*8)); return 0;}'>>"$MYTMP"/platform.c
+     $c "$MYTMP"/platform.c -o "$MYTMP"/platform
+     PLATFORM=`"$MYTMP"/platform`
+     rm "$MYTMP"/platform "$MYTMP"/platform.c >/dev/null 2>&1
+else
+     PLATFORM=$LPSOLVE_PLATFORM
+fi
 
 mkdir bin bin/$PLATFORM >/dev/null 2>&1
 

--- a/xli/xli_MPS/ccc
+++ b/xli/xli_MPS/ccc
@@ -20,16 +20,22 @@ fi
 
 c=${CC:-cc}
 
-MYTMP=`mktemp -d "${TMPDIR:-/tmp}"/lp_solve_XXXXXX`
+# Determine platform if not set.
+# CI will set LPSOLVE_PLATFORM when doing cross-compilation because it cannot run '$MYTMP/platform' executable.
+if [ "$LPSOLVE_PLATFORM" = "" ]; then
+     MYTMP=`mktemp -d "${TMPDIR:-/tmp}"/lp_solve_XXXXXX`
 
-#determine platform (32/64 bit)
->"$MYTMP"/platform.c
-echo '#include <stdlib.h>'>>"$MYTMP"/platform.c
-echo '#include <stdio.h>'>>"$MYTMP"/platform.c
-echo 'int main(){printf("ux%d", (int) (sizeof(void *)*8)); return 0;}'>>"$MYTMP"/platform.c
-$c "$MYTMP"/platform.c -o "$MYTMP"/platform
-PLATFORM=`"$MYTMP"/platform`
-rm "$MYTMP"/platform "$MYTMP"/platform.c >/dev/null 2>&1
+     #determine platform (32/64 bit)
+     >"$MYTMP"/platform.c
+     echo '#include <stdlib.h>'>>"$MYTMP"/platform.c
+     echo '#include <stdio.h>'>>"$MYTMP"/platform.c
+     echo 'int main(){printf("ux%d", (int) (sizeof(void *)*8)); return 0;}'>>"$MYTMP"/platform.c
+     $c "$MYTMP"/platform.c -o "$MYTMP"/platform
+     PLATFORM=`"$MYTMP"/platform`
+     rm "$MYTMP"/platform "$MYTMP"/platform.c >/dev/null 2>&1
+else
+     PLATFORM=$LPSOLVE_PLATFORM
+fi
 
 mkdir bin bin/$PLATFORM >/dev/null 2>&1
 

--- a/xli/xli_XPRESS/ccc
+++ b/xli/xli_XPRESS/ccc
@@ -20,16 +20,22 @@ fi
 
 c=${CC:-cc}
 
-MYTMP=`mktemp -d "${TMPDIR:-/tmp}"/lp_solve_XXXXXX`
+# Determine platform if not set.
+# CI will set LPSOLVE_PLATFORM when doing cross-compilation because it cannot run '$MYTMP/platform' executable.
+if [ "$LPSOLVE_PLATFORM" = "" ]; then
+     MYTMP=`mktemp -d "${TMPDIR:-/tmp}"/lp_solve_XXXXXX`
 
-#determine platform (32/64 bit)
->"$MYTMP"/platform.c
-echo '#include <stdlib.h>'>>"$MYTMP"/platform.c
-echo '#include <stdio.h>'>>"$MYTMP"/platform.c
-echo 'int main(){printf("ux%d", (int) (sizeof(void *)*8)); return 0;}'>>"$MYTMP"/platform.c
-$c "$MYTMP"/platform.c -o "$MYTMP"/platform
-PLATFORM=`"$MYTMP"/platform`
-rm "$MYTMP"/platform "$MYTMP"/platform.c >/dev/null 2>&1
+     #determine platform (32/64 bit)
+     >"$MYTMP"/platform.c
+     echo '#include <stdlib.h>'>>"$MYTMP"/platform.c
+     echo '#include <stdio.h>'>>"$MYTMP"/platform.c
+     echo 'int main(){printf("ux%d", (int) (sizeof(void *)*8)); return 0;}'>>"$MYTMP"/platform.c
+     $c "$MYTMP"/platform.c -o "$MYTMP"/platform
+     PLATFORM=`"$MYTMP"/platform`
+     rm "$MYTMP"/platform "$MYTMP"/platform.c >/dev/null 2>&1
+else
+     PLATFORM=$LPSOLVE_PLATFORM
+fi
 
 mkdir bin bin/$PLATFORM >/dev/null 2>&1
 


### PR DESCRIPTION
This PR adds the following build outputs:
- lp_solve_XXX_dev_ux64.tar.gz
- lp_solve_XXX_dev_ux32.tar.gz
- lp_solve_XXX_exe_ux64.tar.gz
- lp_solve_XXX_exe_ux32.tar.gz

They are built inside a container with an old distro which makes the built binaries dependent on GLIBC v 2.14 which was included in the following distros:
| Distro | Version | Release Date |
| -- | -- | -- |
| Debian | 8 (jessie) | 2015-04-26 |
| Ubuntu | 12.04 | 2012-04-26 |
| CentOS | 7 | 2018-12-04 |
| OpenSuse | 12.1 | 2011-11-16 |
| Rocky Linux | any version |  |

Which means the released files support any OS released since the last 7 years and many more from earlier.

For your information, I found out the version of GLIBC like this:
```sh
$ readelf --dyn-syms -W /path/to/binary | grep @GLIBC_ | sed -E 's/^.*@GLIBC_([^ ]+) .*$/\1/' | sort | uniq
2.14
2.2.5
2.3
```